### PR TITLE
Merge ckeditor5-delete into this package

### DIFF
--- a/src/delete.js
+++ b/src/delete.js
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+import Feature from '../feature.js';
+import DeleteCommand from './deletecommand.js';
+import DeleteObserver from './deleteobserver.js';
+
+/**
+ * The delete and backspace feature. Handles <kbd>Delete</kbd> and <kbd>Backspace</kbd> keys in the editor.
+ *
+ * @memberOf delete
+ * @extends ckeditor5.Feature
+ */
+export default class Delete extends Feature {
+	init() {
+		const editor = this.editor;
+		const editingView = editor.editing.view;
+
+		editingView.addObserver( DeleteObserver );
+
+		editor.commands.set( 'forwardDelete', new DeleteCommand( editor, 'FORWARD' ) );
+		editor.commands.set( 'delete', new DeleteCommand( editor, 'BACKWARD' ) );
+
+		this.listenTo( editingView, 'delete', ( evt, data ) => {
+			editor.execute( data.direction == 'FORWARD' ? 'forwardDelete' : 'delete' );
+			data.preventDefault();
+		} );
+	}
+}

--- a/src/delete.js
+++ b/src/delete.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Feature from '../feature.js';
 import DeleteCommand from './deletecommand.js';
 import DeleteObserver from './deleteobserver.js';
@@ -22,11 +20,11 @@ export default class Delete extends Feature {
 
 		editingView.addObserver( DeleteObserver );
 
-		editor.commands.set( 'forwardDelete', new DeleteCommand( editor, 'FORWARD' ) );
-		editor.commands.set( 'delete', new DeleteCommand( editor, 'BACKWARD' ) );
+		editor.commands.set( 'forwardDelete', new DeleteCommand( editor, 'forward' ) );
+		editor.commands.set( 'delete', new DeleteCommand( editor, 'backward' ) );
 
 		this.listenTo( editingView, 'delete', ( evt, data ) => {
-			editor.execute( data.direction == 'FORWARD' ? 'forwardDelete' : 'delete' );
+			editor.execute( data.direction == 'forward' ? 'forwardDelete' : 'delete' );
 			data.preventDefault();
 		} );
 	}

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -11,7 +11,7 @@ import ChangeBuffer from './changebuffer.js';
 import count from '../utils/count.js';
 
 /**
- * Delete command. Used by the {@link delete.Delete delete feature} to handle <kbd>Delete</kbd> and
+ * Delete command. Used by the {@link typing.Delete delete feature} to handle <kbd>Delete</kbd> and
  * <kbd>Backspace</kbd> keys.
  *
  * @member delete
@@ -33,7 +33,7 @@ export default class DeleteCommand extends Command {
 		 * consume the content when selection is collapsed).
 		 *
 		 * @readonly
-		 * @member {'FORWARD'|'BACKWARD'} delete.DeleteCommand#direction
+		 * @member {'FORWARD'|'BACKWARD'} typing.DeleteCommand#direction
 		 */
 		this.direction = direction;
 
@@ -42,14 +42,14 @@ export default class DeleteCommand extends Command {
 		 *
 		 * @readonly
 		 * @private
-		 * @member {typing.ChangeBuffer} delete.DeleteCommand#buffer
+		 * @member {typing.ChangeBuffer} typing.DeleteCommand#buffer
 		 */
 		this._buffer = new ChangeBuffer( editor.document, editor.config.get( 'undo.step' ) );
 	}
 
 	/**
 	 * Executes the command: depending on whether the selection is collapsed or not, deletes its contents
-	 * or piece of content in the {@link delete.DeleteCommand#direction defined direction}.
+	 * or piece of content in the {@link typing.DeleteCommand#direction defined direction}.
 	 *
 	 * @param {Object} [options] The command options.
 	 * @param {'CHARACTER'} [options.unit='CHARACTER'] See {@link engine.model.composer.modifySelection}'s options.

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Command from '../command/command.js';
 import Selection from '../engine/model/selection.js';
 import ChangeBuffer from './changebuffer.js';
@@ -22,7 +20,7 @@ export default class DeleteCommand extends Command {
 	 * Creates instance of the command;
 	 *
 	 * @param {ckeditor5.Editor} editor
-	 * @param {'FORWARD'|'BACKWARD'} direction The directionality of the delete (in what direction it should
+	 * @param {'forward'|'backward'} direction The directionality of the delete (in what direction it should
 	 * consume the content when selection is collapsed).
 	 */
 	constructor( editor, direction ) {
@@ -33,7 +31,7 @@ export default class DeleteCommand extends Command {
 		 * consume the content when selection is collapsed).
 		 *
 		 * @readonly
-		 * @member {'FORWARD'|'BACKWARD'} typing.DeleteCommand#direction
+		 * @member {'forward'|'backward'} typing.DeleteCommand#direction
 		 */
 		this.direction = direction;
 
@@ -52,7 +50,7 @@ export default class DeleteCommand extends Command {
 	 * or piece of content in the {@link typing.DeleteCommand#direction defined direction}.
 	 *
 	 * @param {Object} [options] The command options.
-	 * @param {'CHARACTER'} [options.unit='CHARACTER'] See {@link engine.model.composer.modifySelection}'s options.
+	 * @param {'character'} [options.unit='character'] See {@link engine.model.composer.modifySelection}'s options.
 	 */
 	_doExecute( options = {} ) {
 		const doc = this.editor.document;

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -1,0 +1,87 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+import Command from '../command/command.js';
+import Selection from '../engine/model/selection.js';
+import ChangeBuffer from './changebuffer.js';
+import count from '../utils/count.js';
+
+/**
+ * Delete command. Used by the {@link delete.Delete delete feature} to handle <kbd>Delete</kbd> and
+ * <kbd>Backspace</kbd> keys.
+ *
+ * @member delete
+ * @extends ckeditor5.command.Command
+ */
+export default class DeleteCommand extends Command {
+	/**
+	 * Creates instance of the command;
+	 *
+	 * @param {ckeditor5.Editor} editor
+	 * @param {'FORWARD'|'BACKWARD'} direction The directionality of the delete (in what direction it should
+	 * consume the content when selection is collapsed).
+	 */
+	constructor( editor, direction ) {
+		super( editor );
+
+		/**
+		 * The directionality of the delete (in what direction it should
+		 * consume the content when selection is collapsed).
+		 *
+		 * @readonly
+		 * @member {'FORWARD'|'BACKWARD'} delete.DeleteCommand#direction
+		 */
+		this.direction = direction;
+
+		/**
+		 * Delete's change buffer used to group subsequent changes into batches.
+		 *
+		 * @readonly
+		 * @private
+		 * @member {typing.ChangeBuffer} delete.DeleteCommand#buffer
+		 */
+		this._buffer = new ChangeBuffer( editor.document, editor.config.get( 'undo.step' ) );
+	}
+
+	/**
+	 * Executes the command: depending on whether the selection is collapsed or not, deletes its contents
+	 * or piece of content in the {@link delete.DeleteCommand#direction defined direction}.
+	 *
+	 * @param {Object} [options] The command options.
+	 * @param {'CHARACTER'} [options.unit='CHARACTER'] See {@link engine.model.composer.modifySelection}'s options.
+	 */
+	_doExecute( options = {} ) {
+		const doc = this.editor.document;
+
+		doc.enqueueChanges( () => {
+			const selection = Selection.createFromSelection( doc.selection );
+
+			// Try to extend the selection in the specified direction.
+			if ( selection.isCollapsed ) {
+				doc.composer.modifySelection( selection, { direction: this.direction, unit: options.unit } );
+			}
+
+			// If selection is still collapsed, then there's nothing to delete.
+			if ( selection.isCollapsed ) {
+				return;
+			}
+
+			let changeCount = 0;
+
+			selection.getFirstRange().getMinimalFlatRanges().forEach( ( range ) => {
+				changeCount += count(
+					range.getWalker( { singleCharacters: true, ignoreElementEnd: true, shallow: true } )
+				);
+			} );
+
+			doc.composer.deleteContents( this._buffer.batch, selection, { merge: true } );
+			this._buffer.input( changeCount );
+
+			doc.selection.setRanges( selection.getRanges(), selection.isBackward );
+		} );
+	}
+}

--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -45,8 +45,8 @@ export default class DeleteObserver extends Observer {
 /**
  * Event fired when the user tries to delete contents (e.g. presses <kbd>Delete</kbd> or <kbd>Backspace</kbd>).
  *
- * Note: This event is fired by the {@link delete.DeleteObserver observer}
- * (usually registered by the {@link delete.Delete delete feature}).
+ * Note: This event is fired by the {@link typing.DeleteObserver observer}
+ * (usually registered by the {@link typing.Delete delete feature}).
  *
  * @event engine.view.Document#delete
  * @param {engine.view.observer.DomEventData} data

--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -1,0 +1,55 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+import Observer from '../engine/view/observer/observer.js';
+import DomEventData from '../engine/view/observer/domeventdata.js';
+import { keyCodes } from '../utils/keyboard.js';
+
+/**
+ * Delete observer introduces the {@link engine.view.Document#delete} event.
+ *
+ * @memberOf delete
+ * @extends engine.view.observer.Observer
+ */
+export default class DeleteObserver extends Observer {
+	constructor( document ) {
+		super( document );
+
+		document.on( 'keydown', ( evt, data ) => {
+			const deleteData = {};
+
+			if ( data.keyCode == keyCodes.delete ) {
+				deleteData.direction = 'FORWARD';
+			} else if ( data.keyCode == keyCodes.backspace ) {
+				deleteData.direction = 'BACKWARD';
+			} else {
+				return;
+			}
+
+			deleteData.unit = data.altKey ? 'WORD' : 'CHARACTER';
+
+			document.fire( 'delete', new DomEventData( document, data.domEvent, deleteData ) );
+		} );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	observe() {}
+}
+
+/**
+ * Event fired when the user tries to delete contents (e.g. presses <kbd>Delete</kbd> or <kbd>Backspace</kbd>).
+ *
+ * Note: This event is fired by the {@link delete.DeleteObserver observer}
+ * (usually registered by the {@link delete.Delete delete feature}).
+ *
+ * @event engine.view.Document#delete
+ * @param {engine.view.observer.DomEventData} data
+ * @param {'FORWARD'|'DELETE'} data.direction The direction in which the deletion should happen.
+ * @param {'CHARACTER'|'WORD'} data.unit The "amount" of content that should be deleted.
+ */

--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Observer from '../engine/view/observer/observer.js';
 import DomEventData from '../engine/view/observer/domeventdata.js';
 import { keyCodes } from '../utils/keyboard.js';
@@ -23,14 +21,14 @@ export default class DeleteObserver extends Observer {
 			const deleteData = {};
 
 			if ( data.keyCode == keyCodes.delete ) {
-				deleteData.direction = 'FORWARD';
+				deleteData.direction = 'forward';
 			} else if ( data.keyCode == keyCodes.backspace ) {
-				deleteData.direction = 'BACKWARD';
+				deleteData.direction = 'backward';
 			} else {
 				return;
 			}
 
-			deleteData.unit = data.altKey ? 'WORD' : 'CHARACTER';
+			deleteData.unit = data.altKey ? 'word' : 'character';
 
 			document.fire( 'delete', new DomEventData( document, data.domEvent, deleteData ) );
 		} );
@@ -50,6 +48,6 @@ export default class DeleteObserver extends Observer {
  *
  * @event engine.view.Document#delete
  * @param {engine.view.observer.DomEventData} data
- * @param {'FORWARD'|'DELETE'} data.direction The direction in which the deletion should happen.
- * @param {'CHARACTER'|'WORD'} data.unit The "amount" of content that should be deleted.
+ * @param {'forward'|'delete'} data.direction The direction in which the deletion should happen.
+ * @param {'character'|'word'} data.unit The "amount" of content that should be deleted.
  */

--- a/src/input.js
+++ b/src/input.js
@@ -19,7 +19,7 @@ import { getCode } from '../utils/keyboard.js';
  * @memberOf typing
  * @extends ckeditor5.Feature
  */
-export default class Typing extends Feature {
+export default class Input extends Feature {
 	/**
 	 * @inheritDoc
 	 */
@@ -31,7 +31,7 @@ export default class Typing extends Feature {
 		 * Typing's change buffer used to group subsequent changes into batches.
 		 *
 		 * @protected
-		 * @member {typing.ChangeBuffer} typing.Typing#_buffer
+		 * @member {typing.ChangeBuffer} typing.Input#_buffer
 		 */
 		this._buffer = new ChangeBuffer( editor.document, editor.config.get( 'typing.undoStep' ) || 20 );
 
@@ -100,7 +100,7 @@ export default class Typing extends Feature {
  * Helper class for translating DOM mutations into model changes.
  *
  * @private
- * @member typing.typing
+ * @member typing.Input
  */
 class MutationHandler {
 	/**
@@ -113,14 +113,14 @@ class MutationHandler {
 		/**
 		 * The editing controller.
 		 *
-		 * @member {engine.EditingController} typing.typing.MutationHandler#editing
+		 * @member {engine.EditingController} typing.Input.MutationHandler#editing
 		 */
 		this.editing = editing;
 
 		/**
 		 * The change buffer.
 		 *
-		 * @member {engine.EditingController} typing.typing.MutationHandler#buffer
+		 * @member {engine.EditingController} typing.Input.MutationHandler#buffer
 		 */
 		this.buffer = buffer;
 
@@ -128,7 +128,7 @@ class MutationHandler {
 		 * Number of inserted characters which need to be feed to the {@link #buffer change buffer}
 		 * on {@link #commit}.
 		 *
-		 * @member {Number} typing.typing.MutationHandler#insertedCharacterCount
+		 * @member {Number} typing.Input.MutationHandler#insertedCharacterCount
 		 */
 		this.insertedCharacterCount = 0;
 
@@ -140,7 +140,7 @@ class MutationHandler {
 		 * for ones like autocorrection or spellchecking. The caret should be placed after the whole piece
 		 * which was corrected (e.g. a word), not after the letter that was replaced.
 		 *
-		 * @member {engine.model.Position} typing.typing.MutationHandler#selectionPosition
+		 * @member {engine.model.Position} typing.Input.MutationHandler#selectionPosition
 		 */
 	}
 

--- a/src/typing.js
+++ b/src/typing.js
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import Feature from '../feature.js';
+import Input from './input';
+import Delete from './delete';
+
+/**
+ * The typing feature. Handles... typing.
+ *
+ * @memberOf typing
+ * @extends ckeditor5.Feature
+ */
+export default class Typing extends Feature {
+	static get requires() {
+		return [ Input, Delete ];
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+	}
+}

--- a/tests/delete.js
+++ b/tests/delete.js
@@ -1,0 +1,59 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+import VirtualTestEditor from '/tests/ckeditor5/_utils/virtualtesteditor.js';
+import Delete from '/ckeditor5/typing/delete.js';
+import DomEventData from '/ckeditor5/engine/view/observer/domeventdata.js';
+
+describe( 'Delete feature', () => {
+	let editor, editingView;
+
+	beforeEach( () => {
+		return VirtualTestEditor.create( {
+				features: [ Delete ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+				editingView = editor.editing.view;
+			} );
+	} );
+
+	it( 'creates two commands', () => {
+		expect( editor.commands.get( 'delete' ) ).to.have.property( 'direction', 'BACKWARD' );
+		expect( editor.commands.get( 'forwardDelete' ) ).to.have.property( 'direction', 'FORWARD' );
+	} );
+
+	it( 'listens to the editing view delete event', () => {
+		const spy = editor.execute = sinon.spy();
+		const view = editor.editing.view;
+		const domEvt = getDomEvent();
+
+		view.fire( 'delete', new DomEventData( editingView, domEvt, {
+			direction: 'FORWARD',
+			unit: 'CHARACTER'
+		} ) );
+
+		expect( spy.calledOnce ).to.be.true;
+		expect( spy.calledWithExactly( 'forwardDelete' ) ).to.be.true;
+
+		expect( domEvt.preventDefault.calledOnce ).to.be.true;
+
+		view.fire( 'delete', new DomEventData( editingView, getDomEvent(), {
+			direction: 'BACKWARD',
+			unit: 'CHARACTER'
+		} ) );
+
+		expect( spy.calledTwice ).to.be.true;
+		expect( spy.calledWithExactly( 'delete' ) ).to.be.true;
+	} );
+
+	function getDomEvent() {
+		return {
+			preventDefault: sinon.spy()
+		};
+	}
+} );

--- a/tests/delete.js
+++ b/tests/delete.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import VirtualTestEditor from '/tests/ckeditor5/_utils/virtualtesteditor.js';
 import Delete from '/ckeditor5/typing/delete.js';
 import DomEventData from '/ckeditor5/engine/view/observer/domeventdata.js';
@@ -23,8 +21,8 @@ describe( 'Delete feature', () => {
 	} );
 
 	it( 'creates two commands', () => {
-		expect( editor.commands.get( 'delete' ) ).to.have.property( 'direction', 'BACKWARD' );
-		expect( editor.commands.get( 'forwardDelete' ) ).to.have.property( 'direction', 'FORWARD' );
+		expect( editor.commands.get( 'delete' ) ).to.have.property( 'direction', 'backward' );
+		expect( editor.commands.get( 'forwardDelete' ) ).to.have.property( 'direction', 'forward' );
 	} );
 
 	it( 'listens to the editing view delete event', () => {
@@ -33,8 +31,8 @@ describe( 'Delete feature', () => {
 		const domEvt = getDomEvent();
 
 		view.fire( 'delete', new DomEventData( editingView, domEvt, {
-			direction: 'FORWARD',
-			unit: 'CHARACTER'
+			direction: 'forward',
+			unit: 'character'
 		} ) );
 
 		expect( spy.calledOnce ).to.be.true;
@@ -43,8 +41,8 @@ describe( 'Delete feature', () => {
 		expect( domEvt.preventDefault.calledOnce ).to.be.true;
 
 		view.fire( 'delete', new DomEventData( editingView, getDomEvent(), {
-			direction: 'BACKWARD',
-			unit: 'CHARACTER'
+			direction: 'backward',
+			unit: 'character'
 		} ) );
 
 		expect( spy.calledTwice ).to.be.true;

--- a/tests/deletecommand-integration.js
+++ b/tests/deletecommand-integration.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import ModelTestEditor from '/tests/ckeditor5/_utils/modeltesteditor.js';
 import DeleteCommand from '/ckeditor5/typing/deletecommand.js';
 import UndoEngine from '/ckeditor5/undo/undoengine.js';
@@ -25,7 +23,7 @@ beforeEach( () => {
 			editor = newEditor;
 			doc = editor.document;
 
-			const command = new DeleteCommand( editor, 'BACKWARD' );
+			const command = new DeleteCommand( editor, 'backward' );
 			editor.commands.set( 'delete', command );
 
 			doc.schema.registerItem( 'p', '$block' );

--- a/tests/deletecommand-integration.js
+++ b/tests/deletecommand-integration.js
@@ -1,0 +1,115 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+import ModelTestEditor from '/tests/ckeditor5/_utils/modeltesteditor.js';
+import DeleteCommand from '/ckeditor5/typing/deletecommand.js';
+import UndoEngine from '/ckeditor5/undo/undoengine.js';
+import { getData, setData } from '/tests/engine/_utils/model.js';
+
+let editor, doc;
+
+beforeEach( () => {
+	return ModelTestEditor.create( {
+			features: [
+				UndoEngine
+			],
+			undo: {
+				step: 3
+			}
+		} )
+		.then( newEditor => {
+			editor = newEditor;
+			doc = editor.document;
+
+			const command = new DeleteCommand( editor, 'BACKWARD' );
+			editor.commands.set( 'delete', command );
+
+			doc.schema.registerItem( 'p', '$block' );
+			doc.schema.registerItem( 'img', '$inline' );
+			doc.schema.allow( { name: '$text', inside: 'img' } );
+		} );
+} );
+
+function assertOutput( output ) {
+	expect( getData( doc ) ).to.equal( output );
+}
+
+describe( 'DeleteCommand integration', () => {
+	it( 'deletes characters (and group changes in batches) and rollbacks', () => {
+		setData( doc, '<p>123456789<selection /></p>' );
+
+		for ( let i = 0; i < 3; ++i ) {
+			editor.execute( 'delete' );
+		}
+
+		editor.execute( 'undo' );
+
+		assertOutput( '<p>123456789<selection /></p>' );
+	} );
+
+	it( 'deletes characters (and group changes in batches) and rollbacks - test step', () => {
+		setData( doc, '<p>123456789<selection /></p>' );
+
+		for ( let i = 0; i < 6; ++i ) {
+			editor.execute( 'delete' );
+		}
+
+		editor.execute( 'undo' );
+
+		assertOutput( '<p>123456<selection /></p>' );
+
+		editor.execute( 'undo' );
+
+		assertOutput( '<p>123456789<selection /></p>' );
+	} );
+
+	it( 'deletes elements (and group changes in batches) and rollbacks', () => {
+		setData( doc, '<p><img>1</img><img>2</img><img>3</img><img>4</img><img>5</img><img>6</img><selection /></p>' );
+
+		for ( let i = 0; i < 3; ++i ) {
+			editor.execute( 'delete' );
+		}
+
+		editor.execute( 'undo' );
+
+		assertOutput( '<p><img>1</img><img>2</img><img>3</img><img>4</img><img>5</img><img>6</img><selection /></p>' );
+	} );
+
+	it( 'merges elements (and group changes in batches) and rollbacks', () => {
+		setData( doc, '<p>123456</p><p><selection />78</p>' );
+
+		for ( let i = 0; i < 6; ++i ) {
+			editor.execute( 'delete' );
+		}
+
+		editor.execute( 'undo' );
+
+		// Deleted 6,5,4, <P> does not count.
+		// It's not the most elegant solution, but is the best if we don't want to make complicated algorithm.
+		assertOutput( '<p>123<selection />78</p>' );
+
+		editor.execute( 'undo' );
+
+		assertOutput( '<p>123456</p><p><selection />78</p>' );
+	} );
+
+	it( 'merges elements (and group changes in batches) and rollbacks - non-collapsed selection', () => {
+		setData( doc, '<p>12345<selection>6</p><p>7</selection>8</p>' );
+
+		editor.execute( 'delete' );
+		editor.execute( 'delete' );
+		editor.execute( 'delete' );
+
+		editor.execute( 'undo' );
+
+		assertOutput( '<p>1234<selection />8</p>' );
+
+		editor.execute( 'undo' );
+
+		assertOutput( '<p>12345<selection>6</p><p>7</selection>8</p>' );
+	} );
+} );

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -1,0 +1,98 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+import ModelTestEditor from '/tests/ckeditor5/_utils/modeltesteditor.js';
+import DeleteCommand from '/ckeditor5/typing/deletecommand.js';
+import { getData, setData } from '/tests/engine/_utils/model.js';
+
+describe( 'DeleteCommand', () => {
+	let editor, doc;
+
+	beforeEach( () => {
+		return ModelTestEditor.create( )
+			.then( newEditor => {
+				editor = newEditor;
+				doc = editor.document;
+
+				const command = new DeleteCommand( editor, 'BACKWARD' );
+				editor.commands.set( 'delete', command );
+
+				doc.schema.registerItem( 'p', '$block' );
+			} );
+	} );
+
+	it( 'has direction', () => {
+		const command = new DeleteCommand( editor, 'FORWARD' );
+
+		expect( command ).to.have.property( 'direction', 'FORWARD' );
+	} );
+
+	describe( 'execute', () => {
+		it( 'uses enqueueChanges', () => {
+			const spy = sinon.spy( doc, 'enqueueChanges' );
+
+			setData( doc, '<p>foo<selection />bar</p>' );
+
+			editor.execute( 'delete' );
+
+			expect( spy.calledOnce ).to.be.true;
+		} );
+
+		it( 'deletes previous character when selection is collapsed', () => {
+			setData( doc, '<p>foo<selection />bar</p>' );
+
+			editor.execute( 'delete' );
+
+			expect( getData( doc, { selection: true } ) ).to.equal( '<p>fo<selection />bar</p>' );
+		} );
+
+		it( 'deletes selection contents', () => {
+			setData( doc, '<p>fo<selection>ob</selection>ar</p>' );
+
+			editor.execute( 'delete' );
+
+			expect( getData( doc, { selection: true } ) ).to.equal( '<p>fo<selection />ar</p>' );
+		} );
+
+		it( 'merges elements', () => {
+			setData( doc, '<p>foo</p><p><selection />bar</p>' );
+
+			editor.execute( 'delete' );
+
+			expect( getData( doc, { selection: true } ) ).to.equal( '<p>foo<selection />bar</p>' );
+		} );
+
+		it( 'does not try to delete when selection is at the boundary', () => {
+			const spy = sinon.spy();
+
+			doc.composer.on( 'deleteContents', spy );
+			setData( doc, '<p><selection />foo</p>' );
+
+			editor.execute( 'delete' );
+
+			expect( getData( doc, { selection: true } ) ).to.equal( '<p><selection />foo</p>' );
+			expect( spy.callCount ).to.equal( 0 );
+		} );
+
+		it( 'passes options to modifySelection', () => {
+			const spy = sinon.spy();
+
+			doc.composer.on( 'modifySelection', spy );
+			setData( doc, '<p>foo<selection />bar</p>' );
+
+			editor.commands.get( 'delete' ).direction = 'FORWARD';
+
+			editor.execute( 'delete', { unit: 'WORD' } );
+
+			expect( spy.callCount ).to.equal( 1 );
+
+			const modifyOpts = spy.args[ 0 ][ 1 ].options;
+			expect( modifyOpts ).to.have.property( 'direction', 'FORWARD' );
+			expect( modifyOpts ).to.have.property( 'unit', 'WORD' );
+		} );
+	} );
+} );

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import ModelTestEditor from '/tests/ckeditor5/_utils/modeltesteditor.js';
 import DeleteCommand from '/ckeditor5/typing/deletecommand.js';
 import { getData, setData } from '/tests/engine/_utils/model.js';
@@ -18,7 +16,7 @@ describe( 'DeleteCommand', () => {
 				editor = newEditor;
 				doc = editor.document;
 
-				const command = new DeleteCommand( editor, 'BACKWARD' );
+				const command = new DeleteCommand( editor, 'backward' );
 				editor.commands.set( 'delete', command );
 
 				doc.schema.registerItem( 'p', '$block' );
@@ -26,9 +24,9 @@ describe( 'DeleteCommand', () => {
 	} );
 
 	it( 'has direction', () => {
-		const command = new DeleteCommand( editor, 'FORWARD' );
+		const command = new DeleteCommand( editor, 'forward' );
 
-		expect( command ).to.have.property( 'direction', 'FORWARD' );
+		expect( command ).to.have.property( 'direction', 'forward' );
 	} );
 
 	describe( 'execute', () => {
@@ -84,15 +82,15 @@ describe( 'DeleteCommand', () => {
 			doc.composer.on( 'modifySelection', spy );
 			setData( doc, '<p>foo<selection />bar</p>' );
 
-			editor.commands.get( 'delete' ).direction = 'FORWARD';
+			editor.commands.get( 'delete' ).direction = 'forward';
 
-			editor.execute( 'delete', { unit: 'WORD' } );
+			editor.execute( 'delete', { unit: 'word' } );
 
 			expect( spy.callCount ).to.equal( 1 );
 
 			const modifyOpts = spy.args[ 0 ][ 1 ].options;
-			expect( modifyOpts ).to.have.property( 'direction', 'FORWARD' );
-			expect( modifyOpts ).to.have.property( 'unit', 'WORD' );
+			expect( modifyOpts ).to.have.property( 'direction', 'forward' );
+			expect( modifyOpts ).to.have.property( 'unit', 'word' );
 		} );
 	} );
 } );

--- a/tests/deleteobserver.js
+++ b/tests/deleteobserver.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import DeleteObserver from '/ckeditor5/typing/deleteobserver.js';
 import ViewDocument from '/ckeditor5/engine/view/document.js';
 import DomEventData from '/ckeditor5/engine/view/observer/domeventdata.js';
@@ -38,8 +36,8 @@ describe( 'DeleteObserver', () => {
 			expect( spy.calledOnce ).to.be.true;
 
 			const data = spy.args[ 0 ][ 1 ];
-			expect( data ).to.have.property( 'direction', 'FORWARD' );
-			expect( data ).to.have.property( 'unit', 'CHARACTER' );
+			expect( data ).to.have.property( 'direction', 'forward' );
+			expect( data ).to.have.property( 'unit', 'character' );
 		} );
 
 		it( 'is fired with a proper direction and unit', () => {
@@ -55,8 +53,8 @@ describe( 'DeleteObserver', () => {
 			expect( spy.calledOnce ).to.be.true;
 
 			const data = spy.args[ 0 ][ 1 ];
-			expect( data ).to.have.property( 'direction', 'BACKWARD' );
-			expect( data ).to.have.property( 'unit', 'WORD' );
+			expect( data ).to.have.property( 'direction', 'backward' );
+			expect( data ).to.have.property( 'unit', 'word' );
 		} );
 
 		it( 'is not fired on keydown when keyCode does not match backspace or delete', () => {

--- a/tests/deleteobserver.js
+++ b/tests/deleteobserver.js
@@ -1,0 +1,80 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+import DeleteObserver from '/ckeditor5/typing/deleteobserver.js';
+import ViewDocument from '/ckeditor5/engine/view/document.js';
+import DomEventData from '/ckeditor5/engine/view/observer/domeventdata.js';
+import { getCode } from '/ckeditor5/utils/keyboard.js';
+
+describe( 'DeleteObserver', () => {
+	let viewDocument, observer;
+
+	beforeEach( () => {
+		viewDocument = new ViewDocument();
+		observer = viewDocument.addObserver( DeleteObserver );
+	} );
+
+	// See ckeditor/ckeditor5-enter#10.
+	it( 'can be initialized', () => {
+		expect( () => {
+			viewDocument.createRoot( document.createElement( 'div' ) );
+		} ).to.not.throw();
+	} );
+
+	describe( 'delete event', () => {
+		it( 'is fired on keydown', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'delete', spy );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'delete' )
+			} ) );
+
+			expect( spy.calledOnce ).to.be.true;
+
+			const data = spy.args[ 0 ][ 1 ];
+			expect( data ).to.have.property( 'direction', 'FORWARD' );
+			expect( data ).to.have.property( 'unit', 'CHARACTER' );
+		} );
+
+		it( 'is fired with a proper direction and unit', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'delete', spy );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'backspace' ),
+				altKey: true
+			} ) );
+
+			expect( spy.calledOnce ).to.be.true;
+
+			const data = spy.args[ 0 ][ 1 ];
+			expect( data ).to.have.property( 'direction', 'BACKWARD' );
+			expect( data ).to.have.property( 'unit', 'WORD' );
+		} );
+
+		it( 'is not fired on keydown when keyCode does not match backspace or delete', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'delete', spy );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: 1
+			} ) );
+
+			expect( spy.calledOnce ).to.be.false;
+		} );
+	} );
+
+	function getDomEvent() {
+		return {
+			preventDefault: sinon.spy()
+		};
+	}
+} );

--- a/tests/input.js
+++ b/tests/input.js
@@ -4,7 +4,7 @@
  */
 
 import VirtualTestEditor from '/tests/ckeditor5/_utils/virtualtesteditor.js';
-import Typing from '/ckeditor5/typing/typing.js';
+import Input from '/ckeditor5/typing/input.js';
 import Paragraph from '/ckeditor5/paragraph/paragraph.js';
 
 import ModelRange from '/ckeditor5/engine/model/range.js';
@@ -20,14 +20,14 @@ import { getCode } from '/ckeditor5/utils/keyboard.js';
 import { getData as getModelData } from '/tests/engine/_utils/model.js';
 import { getData as getViewData } from '/tests/engine/_utils/view.js';
 
-describe( 'Typing feature', () => {
+describe( 'Input feature', () => {
 	let editor, model, modelRoot, view, viewRoot, listenter;
 
 	before( () => {
 		listenter = Object.create( EmitterMixin );
 
 		return VirtualTestEditor.create( {
-				features: [ Typing, Paragraph ]
+				features: [ Input, Paragraph ]
 			} )
 			.then( newEditor => {
 				// Mock image feature.
@@ -63,18 +63,18 @@ describe( 'Typing feature', () => {
 	} );
 
 	it( 'has a buffer configured to default value of config.typing.undoStep', () => {
-		expect( editor.plugins.get( Typing )._buffer ).to.have.property( 'limit', 20 );
+		expect( editor.plugins.get( Input )._buffer ).to.have.property( 'limit', 20 );
 	} );
 
 	it( 'has a buffer configured to config.typing.undoStep', () => {
 		return VirtualTestEditor.create( {
-				features: [ Typing ],
+				features: [ Input ],
 				typing: {
 					undoStep: 5
 				}
 			} )
 			.then( editor => {
-				expect( editor.plugins.get( Typing )._buffer ).to.have.property( 'limit', 5 );
+				expect( editor.plugins.get( Input )._buffer ).to.have.property( 'limit', 5 );
 			} );
 	} );
 
@@ -270,7 +270,7 @@ describe( 'Typing feature', () => {
 
 	describe( 'destroy', () => {
 		it( 'should destroy change buffer', () => {
-			const typing = new Typing( new VirtualTestEditor() );
+			const typing = new Input( new VirtualTestEditor() );
 			typing.init();
 
 			const destroy = typing._buffer.destroy = sinon.spy();

--- a/tests/typing.js
+++ b/tests/typing.js
@@ -1,0 +1,17 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+import Typing from '/ckeditor5/typing/typing.js';
+import Input from '/ckeditor5/typing/input.js';
+import Delete from '/ckeditor5/typing/delete.js';
+
+describe( 'Typing feature', () => {
+	it( 'requires Input and Delete features', () => {
+		const typingRequirements = Typing.requires;
+
+		expect( typingRequirements ).to.contain( Input );
+		expect( typingRequirements ).to.contain( Delete );
+	} );
+} );


### PR DESCRIPTION
Fixes: #17 

Introduced new feature `typing.Typing`. It requires `typing.Input` (old `typing.Typing`) and `typing.Delete` (old `delete.Delete`).