### PR TITLE
Changed spying on engine.model.Document#enqueueChanges

### DIFF
--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -31,9 +31,9 @@ describe( 'DeleteCommand', () => {
 
 	describe( 'execute', () => {
 		it( 'uses enqueueChanges', () => {
-			const spy = sinon.spy( doc, 'enqueueChanges' );
-
 			setData( doc, '<p>foo<selection />bar</p>' );
+
+			const spy = sinon.spy( doc, 'enqueueChanges' );
 
 			editor.execute( 'delete' );
 


### PR DESCRIPTION
Fixes #27.
Model utils method `setData` uses `enqueueChanges` internally so spying should be started after it.