### PR TITLE
Backward delete should modify selection by `codePoint` unit.

### DIFF
--- a/src/delete.js
+++ b/src/delete.js
@@ -24,7 +24,7 @@ export default class Delete extends Feature {
 		editor.commands.set( 'delete', new DeleteCommand( editor, 'backward' ) );
 
 		this.listenTo( editingView, 'delete', ( evt, data ) => {
-			editor.execute( data.direction == 'forward' ? 'forwardDelete' : 'delete' );
+			editor.execute( data.direction == 'forward' ? 'forwardDelete' : 'delete', { unit: data.unit } );
 			data.preventDefault();
 		} );
 	}

--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -22,13 +22,15 @@ export default class DeleteObserver extends Observer {
 
 			if ( data.keyCode == keyCodes.delete ) {
 				deleteData.direction = 'forward';
+				deleteData.unit = 'character';
 			} else if ( data.keyCode == keyCodes.backspace ) {
 				deleteData.direction = 'backward';
+				deleteData.unit = 'codePoint';
 			} else {
 				return;
 			}
 
-			deleteData.unit = data.altKey ? 'word' : 'character';
+			deleteData.unit = data.altKey ? 'word' : deleteData.unit;
 
 			document.fire( 'delete', new DomEventData( document, data.domEvent, deleteData ) );
 		} );

--- a/tests/delete.js
+++ b/tests/delete.js
@@ -36,7 +36,7 @@ describe( 'Delete feature', () => {
 		} ) );
 
 		expect( spy.calledOnce ).to.be.true;
-		expect( spy.calledWithExactly( 'forwardDelete' ) ).to.be.true;
+		expect( spy.calledWithMatch( 'forwardDelete', { unit: 'character' } ) ).to.be.true;
 
 		expect( domEvt.preventDefault.calledOnce ).to.be.true;
 
@@ -46,7 +46,7 @@ describe( 'Delete feature', () => {
 		} ) );
 
 		expect( spy.calledTwice ).to.be.true;
-		expect( spy.calledWithExactly( 'delete' ) ).to.be.true;
+		expect( spy.calledWithMatch( 'delete', { unit: 'character' } ) ).to.be.true;
 	} );
 
 	function getDomEvent() {


### PR DESCRIPTION
Fixes #33.