### PR TITLE
T/69

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -286,6 +286,7 @@ const safeKeycodes = [
 	getCode( 'arrowRight' ),
 	getCode( 'arrowDown' ),
 	getCode( 'arrowLeft' ),
+	9,  // Tab
 	16, // Shift
 	17, // Ctrl
 	18, // Alt

--- a/tests/input.js
+++ b/tests/input.js
@@ -307,6 +307,17 @@ describe( 'Input feature', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
 		} );
 
+		it( 'should do nothing on tab key', () => {
+			model.enqueueChanges( () => {
+				model.selection.setRanges( [
+					ModelRange.createFromParentsAndOffsets( modelRoot.getChild( 0 ), 2, modelRoot.getChild( 0 ), 4 ) ] );
+			} );
+
+			view.fire( 'keydown', { keyCode: 9 } ); // Tab
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
+		} );
+
 		it( 'should do nothing if selection is collapsed', () => {
 			view.fire( 'keydown', { ctrlKey: true, keyCode: getCode( 'c' ) } );
 

--- a/tests/input.js
+++ b/tests/input.js
@@ -307,6 +307,7 @@ describe( 'Input feature', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
 		} );
 
+		// #69
 		it( 'should do nothing on tab key', () => {
 			model.enqueueChanges( () => {
 				model.selection.setRanges( [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Tab key should not delete selected text. Closes: #69.

---

### Additional information

I added separate test case (instead of using generic `should do nothing on non printable keys` tc) due to the fact that the <kbd>Tab</kbd> was skipped earlier so there should be explicit test for it.
