### PR TITLE
T/79 - Use typing.undoStep in both InputCommand and DeleteCommand

### DIFF
--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -45,7 +45,7 @@ export default class DeleteCommand extends Command {
 		 * @private
 		 * @member {typing.ChangeBuffer} #buffer
 		 */
-		this._buffer = new ChangeBuffer( editor.document, editor.config.get( 'undo.step' ) );
+		this._buffer = new ChangeBuffer( editor.document, editor.config.get( 'typing.undoStep' ) );
 	}
 
 	/**

--- a/tests/deletecommand-integration.js
+++ b/tests/deletecommand-integration.js
@@ -16,8 +16,8 @@ describe( 'DeleteCommand integration', () => {
 				plugins: [
 					UndoEngine
 				],
-				undo: {
-					step: 3
+				typing: {
+					undoStep: 3
 				}
 			} )
 			.then( newEditor => {


### PR DESCRIPTION
Fix: Use `typing.undoStep` in both `InputCommand` and `DeleteCommand`. Closes #79.

BREAKING CHANGE: The `undo.step` configuration option was replaced by `typing.undoStep` in `DeleteCommand`. The `typing.undoStep` works in the same manner as `undo.step` an should be used instead of it. See #79.
