### PR TITLE
T/82 Spanish accent character is removed while typed in non-collapsed selection.

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -259,6 +259,7 @@ const safeKeycodes = [
 	34, // PageDown
 	35, // Home
 	36, // End
+	229 // Composition start key
 ];
 
 // Function keys.

--- a/tests/input.js
+++ b/tests/input.js
@@ -429,6 +429,18 @@ describe( 'Input feature', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
 		} );
 
+		// #82
+		it( 'should do nothing on composition start key', () => {
+			model.enqueueChanges( () => {
+				model.selection.setRanges( [
+					ModelRange.createFromParentsAndOffsets( modelRoot.getChild( 0 ), 2, modelRoot.getChild( 0 ), 4 ) ] );
+			} );
+
+			view.fire( 'keydown', { keyCode: 229 } );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
+		} );
+
 		it( 'should do nothing if selection is collapsed', () => {
 			view.fire( 'keydown', { ctrlKey: true, keyCode: getCode( 'c' ) } );
 

--- a/tests/manual/82/1.html
+++ b/tests/manual/82/1.html
@@ -1,0 +1,3 @@
+<div id="editor">
+	<p>This is an editor instance.</p>
+</div>

--- a/tests/manual/82/1.js
+++ b/tests/manual/82/1.js
@@ -21,9 +21,9 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 	plugins: [ Enter, Typing, Paragraph, Undo, Heading ],
 	toolbar: [ 'headings', 'undo', 'redo' ]
 } )
-	.then( editor => {
-		window.editor = editor;
-	} )
-	.catch( err => {
-		console.error( err.stack );
-	} );
+.then( editor => {
+	window.editor = editor;
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/manual/82/1.js
+++ b/tests/manual/82/1.js
@@ -1,0 +1,29 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classic';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Typing from '../../../src/typing';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Undo from '@ckeditor/ckeditor5-undo/src/undo';
+import { getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+window.setInterval( function() {
+	console.log( getData( window.editor.document ) );
+}, 3000 );
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ Enter, Typing, Paragraph, Undo, Heading ],
+	toolbar: [ 'headings', 'undo', 'redo' ]
+} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/manual/82/1.md
+++ b/tests/manual/82/1.md
@@ -1,0 +1,10 @@
+## Input - non-collapsed IME
+
+_Check composition on non-collapsed selection_:
+
+* Hiragana,
+* Spanish-ISO: accent (it's under `'`) + "a",
+* MacOS: long "a" press (accent balloon).
+
+**Expected**: Composition should be started correctly, character starting the composition should be visible. The selected
+text should be replaced by composition start character.


### PR DESCRIPTION
Fix: Spanish accent character properly inserted on non-collapsed selection. Closes #82.