### PR TITLE
T/52;T/77 Manual/Integration tests covering typing space / spellchecking corrections on the end of the block element.

### DIFF
--- a/tests/bogusbr-integration.js
+++ b/tests/bogusbr-integration.js
@@ -8,13 +8,13 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classic';
 import MutationObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mutationobserver';
 
-import Typing from '../../src/typing';
+import Typing from '../src/typing';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
-describe( 'Bug ckeditor5-typing#52', () => {
+describe( 'Bogus BR Integration', () => {
 	let editor;
 	let domRoot;
 	let mutationObserver;
@@ -135,6 +135,38 @@ describe( 'Bug ckeditor5-typing#52', () => {
 				generateMutationMock( 'childList', paragraph, text, [ br ] ),
 				generateMutationMock( 'characterData', text ),
 				generateMutationMock( 'characterData', text )
+			] );
+		} );
+
+		it( 'word is properly corrected on the end of the block element (with bogus br)', ( done ) => {
+			editor.document.enqueueChanges( () => {
+				editor.editing.view.getDomRoot().focus();
+				setData( editor.document, '<paragraph>Foo hous[]</paragraph>' );
+			} );
+
+			editor.document.once( 'changesDone', () => {
+				expect( editor.getData() ).to.equal( '<p>Foo house</p>' );
+				done();
+			}, { priority: 'low' } );
+
+			const paragraph = domRoot.childNodes[ 0 ];
+			const text = paragraph.childNodes [ 0 ];
+			const br = document.createElement( 'br' );
+
+			mutationObserver.disable();
+
+			text.data = 'Foo house';
+
+			mutationObserver.enable();
+
+			mutationObserver._onMutations( [
+				generateMutationMock( 'characterData', text ),
+				generateMutationMock( 'characterData', text ),
+				generateMutationMock( 'characterData', text ),
+				generateMutationMock( 'childList', paragraph, text, [ br ] ),
+				generateMutationMock( 'characterData', text ),
+				generateMutationMock( 'characterData', text ),
+				generateMutationMock( 'characterData', text ),
 			] );
 		} );
 	} );

--- a/tests/bogusbr-integration.js
+++ b/tests/bogusbr-integration.js
@@ -5,7 +5,8 @@
 
 /* globals document */
 
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classic';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+
 import MutationObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mutationobserver';
 
 import Typing from '../src/typing';
@@ -14,16 +15,14 @@ import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
-describe( 'Bogus BR Integration', () => {
-	let editor;
-	let domRoot;
-	let mutationObserver;
+describe( 'Bogus BR integration', () => {
+	let editor, domRoot, mutationObserver, editorElement;
 
 	beforeEach( () => {
-		const container = document.createElement( 'div' );
-		document.body.appendChild( container );
+		editorElement = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
 
-		return ClassicEditor.create( container, {
+		return ClassicTestEditor.create( editorElement, {
 			plugins: [ Typing, Paragraph, Bold ]
 		} )
 		.then( newEditor => {
@@ -31,6 +30,12 @@ describe( 'Bogus BR Integration', () => {
 			domRoot = editor.editing.view.getDomRoot();
 			mutationObserver = editor.editing.view.getObserver( MutationObserver );
 		} );
+	} );
+
+	afterEach( () => {
+		editorElement.remove();
+
+		return editor.destroy();
 	} );
 
 	describe( 'insertText', () => {

--- a/tests/inputcommand-integration.js
+++ b/tests/inputcommand-integration.js
@@ -22,10 +22,10 @@ import { getData as getModelData } from  '@ckeditor/ckeditor5-engine/src/dev-uti
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
 describe( 'InputCommand integration', () => {
-	let editor, doc, viewDocument, boldView, italicView;
+	let editor, doc, viewDocument, boldView, italicView, editorElement;
 
 	beforeEach( () => {
-		const editorElement = document.createElement( 'div' );
+		editorElement = document.createElement( 'div' );
 		document.body.appendChild( editorElement );
 
 		return ClassicTestEditor.create( editorElement, {
@@ -43,6 +43,8 @@ describe( 'InputCommand integration', () => {
 	} );
 
 	afterEach( () => {
+		editorElement.remove();
+
 		return editor.destroy();
 	} );
 

--- a/tests/manual/52/1.html
+++ b/tests/manual/52/1.html
@@ -1,0 +1,6 @@
+<div id="editor">
+	<h2>Heading 1</h2>
+	<h3><em>Heading 2</em></h3>
+	<p><strong>Bolded text!</strong></p>
+	<p><em>This</em> is an <strong>editor</strong> instance.</p>
+</div>

--- a/tests/manual/52/1.js
+++ b/tests/manual/52/1.js
@@ -1,0 +1,29 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classic';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import EssentialsPreset from '@ckeditor/ckeditor5-presets/src/essentials';
+import { getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+window.setInterval( function() {
+	console.log( getData( window.editor.document ) );
+}, 3000 );
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ EssentialsPreset, Paragraph, Bold, Italic, Heading ],
+	toolbar: [ 'headings', 'bold', 'italic', 'undo', 'redo' ]
+} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/tests/manual/52/1.js
+++ b/tests/manual/52/1.js
@@ -21,9 +21,9 @@ ClassicEditor.create( document.querySelector( '#editor' ), {
 	plugins: [ EssentialsPreset, Paragraph, Bold, Italic, Heading ],
 	toolbar: [ 'headings', 'bold', 'italic', 'undo', 'redo' ]
 } )
-	.then( editor => {
-		window.editor = editor;
-	} )
-	.catch( err => {
-		console.error( err.stack );
-	} );
+.then( editor => {
+	window.editor = editor;
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/manual/52/1.md
+++ b/tests/manual/52/1.md
@@ -1,0 +1,3 @@
+## Typing - space on the end of the line ([#52](https://github.com/ckeditor/ckeditor5-typing/issues/52))
+
+For every line of text check if it possible to type spaces on the end of that line.

--- a/tests/tickets/52.js
+++ b/tests/tickets/52.js
@@ -1,0 +1,155 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classic';
+import MutationObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mutationobserver';
+
+import Typing from '../../src/typing';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+
+import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+describe( 'Bug ckeditor5-typing#52', () => {
+	let editor;
+	let domRoot;
+	let mutationObserver;
+
+	beforeEach( () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		return ClassicEditor.create( container, {
+			plugins: [ Typing, Paragraph, Bold ]
+		} )
+		.then( newEditor => {
+			editor = newEditor;
+			domRoot = editor.editing.view.getDomRoot();
+			mutationObserver = editor.editing.view.getObserver( MutationObserver );
+		} );
+	} );
+
+	describe( 'insertText', () => {
+		// Tests using 'insertText' generates same mutations as typing. This means they will behave
+		// a little different in every browser (as native mutations may be different in different browsers).
+
+		it( 'space is inserted on the end of the line (paragraph)', ( done ) => {
+			editor.document.enqueueChanges( () => {
+				editor.editing.view.getDomRoot().focus();
+				setData( editor.document, '<paragraph>Foo[]</paragraph>' );
+			} );
+
+			editor.document.once( 'changesDone', () => {
+				expect( editor.getData() ).to.equal( '<p>Foo&nbsp;</p>' );
+				done();
+			}, { priority: 'low' } );
+
+			document.execCommand( 'insertText', false, ' ' );
+		} );
+
+		it( 'space is inserted on the end of the line (empty paragraph)', ( done ) => {
+			editor.document.enqueueChanges( () => {
+				editor.editing.view.getDomRoot().focus();
+				setData( editor.document, '<paragraph>[]</paragraph>' );
+			} );
+
+			editor.document.once( 'changesDone', () => {
+				expect( editor.getData() ).to.equal( '<p>&nbsp;</p>' );
+				done();
+			}, { priority: 'low' } );
+
+			document.execCommand( 'insertText', false, ' ' );
+		} );
+
+		it( 'space is inserted on the end of the line (bold)', ( done ) => {
+			editor.document.enqueueChanges( () => {
+				editor.editing.view.getDomRoot().focus();
+				setData( editor.document, '<paragraph><$text bold="true">Foo[]</$text></paragraph>' );
+			} );
+
+			editor.document.once( 'changesDone', () => {
+				expect( editor.getData() ).to.equal( '<p><strong>Foo&nbsp;</strong></p>' );
+				done();
+			}, { priority: 'low' } );
+
+			document.execCommand( 'insertText', false, ' ' );
+		} );
+	} );
+
+	describe( 'mutations', () => {
+		// This tests use fixed list of mutation mocks to simulate specific browser behaviours.
+
+		it( 'space is inserted on the end of the paragraph', ( done ) => {
+			editor.document.enqueueChanges( () => {
+				editor.editing.view.getDomRoot().focus();
+				setData( editor.document, '<paragraph>Foo[]</paragraph>' );
+			} );
+
+			editor.document.once( 'changesDone', () => {
+				expect( editor.getData() ).to.equal( '<p>Foo&nbsp;</p>' );
+				done();
+			}, { priority: 'low' } );
+
+			const mutationTarget = domRoot.childNodes[ 0 ].childNodes[ 0 ];
+
+			mutationObserver.disable();
+
+			mutationTarget.data = 'Foo ';
+
+			mutationObserver.enable();
+
+			mutationObserver._onMutations( [
+				generateMutationMock( 'characterData', mutationTarget ),
+				generateMutationMock( 'characterData', mutationTarget ),
+				generateMutationMock( 'characterData', mutationTarget )
+			] );
+		} );
+
+		it( 'space is inserted on the end of the line paragraph (with bogus br)', ( done ) => {
+			editor.document.enqueueChanges( () => {
+				editor.editing.view.getDomRoot().focus();
+				setData( editor.document, '<paragraph>Foo[]</paragraph>' );
+			} );
+
+			editor.document.once( 'changesDone', () => {
+				expect( editor.getData() ).to.equal( '<p>Foo&nbsp;</p>' );
+				done();
+			}, { priority: 'low' } );
+
+			const paragraph = domRoot.childNodes[ 0 ];
+			const text = paragraph.childNodes [ 0 ];
+			const br = document.createElement( 'br' );
+
+			mutationObserver.disable();
+
+			text.data = 'Foo ';
+
+			mutationObserver.enable();
+
+			mutationObserver._onMutations( [
+				generateMutationMock( 'characterData', text ),
+				generateMutationMock( 'childList', paragraph, text, [ br ] ),
+				generateMutationMock( 'characterData', text ),
+				generateMutationMock( 'characterData', text )
+			] );
+		} );
+	} );
+
+	function generateMutationMock( type, target, previousSibling, addedNodes ) {
+		return {
+			addedNodes: addedNodes || [],
+			attributeName: null,
+			attributeNamespace: null,
+			nextSibling: null,
+			oldValue: null,
+			previousSibling: previousSibling || null,
+			removedNodes: [],
+			target: target,
+			type: type
+		};
+	}
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Manual/Integration tests covering typing space / spellchecking corrections on the end of the block element. Closes #52. Closes #77.

---

### Additional information
The #77 is already covered in [spellchecking manual test](https://github.com/ckeditor/ckeditor5-typing/blob/t/52/tests/manual/spellchecking.md).
