### PR TITLE
T/61: Backspace on a fully selected content or at the beginning of the first block should ensure that paragraph is left

### DIFF
--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -10,6 +10,9 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
 import ChangeBuffer from './changebuffer';
+import Position from '@ckeditor/ckeditor5-engine/src/model/position';
+import Element from '@ckeditor/ckeditor5-engine/src/model/element';
+import Range from '@ckeditor/ckeditor5-engine/src/model/range';
 import count from '@ckeditor/ckeditor5-utils/src/count';
 
 /**
@@ -60,6 +63,8 @@ export default class DeleteCommand extends Command {
 	execute( options = {} ) {
 		const doc = this.editor.document;
 		const dataController = this.editor.data;
+		const root = doc.getRoot();
+		const schema = doc.schema;
 
 		doc.enqueueChanges( () => {
 			this._buffer.lock();
@@ -90,6 +95,25 @@ export default class DeleteCommand extends Command {
 			doc.selection.setRanges( selection.getRanges(), selection.isBackward );
 
 			this._buffer.unlock();
+
+			// Check whether the whole content has been removed and whether schema allows inserting a paragraph.
+			// If the user will typing after removing the whole content, the user's input should be wrapped in the paragraph
+			// instead of any other element. See https://github.com/ckeditor/ckeditor5-typing/issues/61.
+			if (
+				Position.createAt( root ).isTouching( selection.getFirstPosition() ) &&
+				Position.createAt( root, 'end' ).isTouching( selection.getLastPosition() ) &&
+				schema.check( { name: 'paragraph', inside: root.name } )
+			) {
+				this._buffer.batch.remove(
+					new Range( new Position( root, [ 0 ] ), new Position( root, [ 1 ] ) )
+				);
+
+				this._buffer.batch.insert(
+					new Position( root, [ 0 ] ), new Element( 'paragraph' )
+				);
+
+				doc.selection.setRanges( new Range( new Position( root, [ 0 ] ) ) );
+			}
 		} );
 	}
 }

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -92,10 +92,6 @@ export default class DeleteCommand extends Command {
 			dataController.deleteContent( selection, this._buffer.batch );
 			this._buffer.input( changeCount );
 
-			doc.selection.setRanges( selection.getRanges(), selection.isBackward );
-
-			this._buffer.unlock();
-
 			// Check whether the whole content has been removed and whether schema allows inserting a paragraph.
 			// If the user will typing after removing the whole content, the user's input should be wrapped in the paragraph
 			// instead of any other element. See https://github.com/ckeditor/ckeditor5-typing/issues/61.
@@ -104,6 +100,8 @@ export default class DeleteCommand extends Command {
 				Position.createAt( root, 'end' ).isTouching( selection.getLastPosition() ) &&
 				schema.check( { name: 'paragraph', inside: root.name } )
 			) {
+				dataController.deleteContent( selection, this._buffer.batch );
+
 				this._buffer.batch.remove(
 					new Range( new Position( root, [ 0 ] ), new Position( root, [ 1 ] ) )
 				);
@@ -111,9 +109,11 @@ export default class DeleteCommand extends Command {
 				this._buffer.batch.insert(
 					new Position( root, [ 0 ] ), new Element( 'paragraph' )
 				);
-
-				doc.selection.setRanges( new Range( new Position( root, [ 0 ] ) ) );
 			}
+
+			doc.selection.setRanges( selection.getRanges(), selection.isBackward );
+
+			this._buffer.unlock();
 		} );
 	}
 }

--- a/tests/inputcommand-integration.js
+++ b/tests/inputcommand-integration.js
@@ -13,7 +13,6 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
-import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 
 import Range from '@ckeditor/ckeditor5-engine/src/model/range';
 import Position from '@ckeditor/ckeditor5-engine/src/model/position';
@@ -29,7 +28,7 @@ describe( 'InputCommand integration', () => {
 		document.body.appendChild( editorElement );
 
 		return ClassicTestEditor.create( editorElement, {
-			plugins: [ Typing, Paragraph, Undo, Bold, Italic, Enter, Heading ],
+			plugins: [ Typing, Paragraph, Undo, Bold, Italic, Enter ],
 			typing: { undoStep: 3 }
 		} )
 		.then( newEditor => {
@@ -210,46 +209,6 @@ describe( 'InputCommand integration', () => {
 
 			expectOutput( '<paragraph>Foo <$text bold="true">B[]</$text> Bar</paragraph>',
 				'<p>Foo <strong>B{}</strong> Bar</p>' );
-		} );
-
-		// See https://github.com/ckeditor/ckeditor5-typing/issues/61.
-		it( 'leaves an empty paragraph after removing the whole content from editor #1', () => {
-			setModelData( doc, '[<heading1>Header 1</heading1><paragraph>Some text.</paragraph>]' );
-
-			editor.execute( 'delete' );
-
-			expectOutput( '<paragraph>[]</paragraph>', '<p>[]</p>' );
-		} );
-
-		// See https://github.com/ckeditor/ckeditor5-typing/issues/61.
-		it( 'leaves an empty paragraph after removing the whole content from editor #2', () => {
-			setModelData( doc, '<heading1>[Header 1</heading1><paragraph>Some text.]</paragraph>' );
-
-			editor.execute( 'delete' );
-
-			expectOutput( '<paragraph>[]</paragraph>', '<p>[]</p>' );
-		} );
-
-		// See https://github.com/ckeditor/ckeditor5-typing/issues/61.
-		it( 'wraps inserted text in a paragraph after typing in editor with selected the whole content #1', () => {
-			setModelData( doc, '[<heading1>Header 1</heading1><paragraph>Some text.</paragraph>]' );
-
-			editor.execute( 'delete' );
-
-			simulateTyping( '123' );
-
-			expectOutput( '<paragraph>123[]</paragraph>', '<p>123{}</p>' );
-		} );
-
-		// See https://github.com/ckeditor/ckeditor5-typing/issues/61.
-		it( 'wraps inserted text in a paragraph after typing in editor with selected the whole content #2', () => {
-			setModelData( doc, '<heading1>[Header 1</heading1><paragraph>Some text.]</paragraph>' );
-
-			editor.execute( 'delete' );
-
-			simulateTyping( '123' );
-
-			expectOutput( '<paragraph>123[]</paragraph>', '<p>123{}</p>' );
 		} );
 	} );
 } );

--- a/tests/inputcommand-integration.js
+++ b/tests/inputcommand-integration.js
@@ -13,6 +13,7 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 
 import Range from '@ckeditor/ckeditor5-engine/src/model/range';
 import Position from '@ckeditor/ckeditor5-engine/src/model/position';
@@ -28,7 +29,7 @@ describe( 'InputCommand integration', () => {
 		document.body.appendChild( editorElement );
 
 		return ClassicTestEditor.create( editorElement, {
-			plugins: [ Typing, Paragraph, Undo, Bold, Italic, Enter ],
+			plugins: [ Typing, Paragraph, Undo, Bold, Italic, Enter, Heading ],
 			typing: { undoStep: 3 }
 		} )
 		.then( newEditor => {
@@ -209,6 +210,46 @@ describe( 'InputCommand integration', () => {
 
 			expectOutput( '<paragraph>Foo <$text bold="true">B[]</$text> Bar</paragraph>',
 				'<p>Foo <strong>B{}</strong> Bar</p>' );
+		} );
+
+		// See https://github.com/ckeditor/ckeditor5-typing/issues/61.
+		it( 'leaves an empty paragraph after removing the whole content from editor #1', () => {
+			setModelData( doc, '[<heading1>Header 1</heading1><paragraph>Some text.</paragraph>]' );
+
+			editor.execute( 'delete' );
+
+			expectOutput( '<paragraph>[]</paragraph>', '<p>[]</p>' );
+		} );
+
+		// See https://github.com/ckeditor/ckeditor5-typing/issues/61.
+		it( 'leaves an empty paragraph after removing the whole content from editor #2', () => {
+			setModelData( doc, '<heading1>[Header 1</heading1><paragraph>Some text.]</paragraph>' );
+
+			editor.execute( 'delete' );
+
+			expectOutput( '<paragraph>[]</paragraph>', '<p>[]</p>' );
+		} );
+
+		// See https://github.com/ckeditor/ckeditor5-typing/issues/61.
+		it( 'wraps inserted text in a paragraph after typing in editor with selected the whole content #1', () => {
+			setModelData( doc, '[<heading1>Header 1</heading1><paragraph>Some text.</paragraph>]' );
+
+			editor.execute( 'delete' );
+
+			simulateTyping( '123' );
+
+			expectOutput( '<paragraph>123[]</paragraph>', '<p>123{}</p>' );
+		} );
+
+		// See https://github.com/ckeditor/ckeditor5-typing/issues/61.
+		it( 'wraps inserted text in a paragraph after typing in editor with selected the whole content #2', () => {
+			setModelData( doc, '<heading1>[Header 1</heading1><paragraph>Some text.]</paragraph>' );
+
+			editor.execute( 'delete' );
+
+			simulateTyping( '123' );
+
+			expectOutput( '<paragraph>123[]</paragraph>', '<p>123{}</p>' );
 		} );
 	} );
 } );

--- a/tests/tickets/61.js
+++ b/tests/tickets/61.js
@@ -1,0 +1,104 @@
+/**
+ * @license Copyright (c) 2003-2017, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+
+import Typing from '../../src/typing';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Undo from '@ckeditor/ckeditor5-undo/src/undo';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+
+import { setData as setModelData, getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
+
+describe( 'Bug ckeditor5-typing#61', () => {
+	let editor, doc, viewDocument, editorElement;
+
+	beforeEach( () => {
+		editorElement = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
+
+		return ClassicTestEditor.create( editorElement, {
+			plugins: [ Typing, Paragraph, Undo, Bold, Italic, Enter, Heading ],
+			typing: { undoStep: 3 }
+		} )
+		.then( newEditor => {
+			editor = newEditor;
+			doc = editor.document;
+			viewDocument = editor.editing.view;
+		} );
+	} );
+
+	afterEach( () => {
+		editorElement.remove();
+
+		return editor.destroy();
+	} );
+
+	function expectOutput( modelOutput, viewOutput ) {
+		expect( getModelData( editor.document ) ).to.equal( modelOutput );
+		expect( getViewData( viewDocument ) ).to.equal( viewOutput );
+	}
+
+	function simulateTyping( text ) {
+		// While typing, every character is an atomic change.
+		text.split( '' ).forEach( character => {
+			editor.execute( 'input', {
+				text: character
+			} );
+		} );
+	}
+
+	it( 'leaves an empty paragraph after removing the whole content from editor #1', () => {
+		setModelData( doc, '[<heading1>Header 1</heading1><paragraph>Some text.</paragraph>]' );
+
+		editor.execute( 'delete' );
+
+		expectOutput( '<paragraph>[]</paragraph>', '<p>[]</p>' );
+	} );
+
+	it( 'leaves an empty paragraph after removing the whole content from editor #2', () => {
+		setModelData( doc, '<heading1>[Header 1</heading1><paragraph>Some text.]</paragraph>' );
+
+		editor.execute( 'delete' );
+
+		expectOutput( '<paragraph>[]</paragraph>', '<p>[]</p>' );
+	} );
+
+	it( 'wraps inserted text in a paragraph after typing in editor with selected the whole content #1', () => {
+		setModelData( doc, '[<heading1>Header 1</heading1><paragraph>Some text.</paragraph>]' );
+
+		editor.execute( 'delete' );
+
+		simulateTyping( '123' );
+
+		expectOutput( '<paragraph>123[]</paragraph>', '<p>123{}</p>' );
+	} );
+
+	it( 'wraps inserted text in a paragraph after typing in editor with selected the whole content #2', () => {
+		setModelData( doc, '<heading1>[Header 1</heading1><paragraph>Some text.]</paragraph>' );
+
+		editor.execute( 'delete' );
+
+		simulateTyping( '123' );
+
+		expectOutput( '<paragraph>123[]</paragraph>', '<p>123{}</p>' );
+	} );
+
+	it( 'paragraph created after removing the whole content should not have any attribute', () => {
+		setModelData( doc, '<paragraph><$text bold="true">[Some text.]</$text></paragraph>' );
+
+		editor.execute( 'delete' );
+
+		simulateTyping( '123' );
+
+		expectOutput( '<paragraph>123[]</paragraph>', '<p>123{}</p>' );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Backspace on a fully selected content or at the beginning of the first block will ensure that paragraph is left. Closes #61.