### PR TITLE
Prevent from modifying document by Input feature when InputCommand is disabled

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -42,7 +42,7 @@ export default class Input extends Plugin {
 		editor.commands.add( 'input', inputCommand );
 
 		this.listenTo( editingView, 'keydown', ( evt, data ) => {
-			this._handleKeydown( data, inputCommand.buffer );
+			this._handleKeydown( data, inputCommand );
 		}, { priority: 'lowest' } );
 
 		this.listenTo( editingView, 'mutations', ( evt, mutations, viewSelection ) => {
@@ -64,10 +64,20 @@ export default class Input extends Plugin {
 	 *
 	 * @private
 	 * @param {module:engine/view/observer/keyobserver~KeyEventData} evtData
-	 * @param {module:typing/changebuffer~ChangeBuffer} buffer
+	 * @param {module:typing/inputcommand~InputCommand} inputCommand
 	 */
-	_handleKeydown( evtData, buffer ) {
+	_handleKeydown( evtData, inputCommand ) {
 		const doc = this.editor.document;
+		const buffer = inputCommand.buffer;
+
+		// By relying on the state of the input command we allow disabling the entire input easily
+		// by just disabling the input command. We could’ve used here the delete command but that
+		// would mean requiring the delete feature which would block loading one without the other.
+		// We could also check the editor.isReadOnly property, but that wouldn't allow to block
+		// the input without blocking other features.
+		if ( !inputCommand.isEnabled ) {
+			return;
+		}
 
 		if ( isSafeKeystroke( evtData ) || doc.selection.isCollapsed ) {
 			return;

--- a/tests/input.js
+++ b/tests/input.js
@@ -520,6 +520,26 @@ describe( 'Input feature', () => {
 			expect( lockSpy.callCount ).to.be.equal( 0 );
 			expect( unlockSpy.callCount ).to.be.equal( 0 );
 		} );
+
+		it( 'should not modify document when input command is disabled and selection is collapsed', () => {
+			setModelData( model, '<paragraph>foo[]bar</paragraph>' );
+
+			editor.commands.get( 'input' ).isEnabled = false;
+
+			view.fire( 'keydown', { keyCode: getCode( 'b' ) } );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>foo[]bar</paragraph>' );
+		} );
+
+		it( 'should not modify document when input command is disabled and selection is non-collapsed', () => {
+			setModelData( model, '<paragraph>fo[ob]ar</paragraph>' );
+
+			editor.commands.get( 'input' ).isEnabled = false;
+
+			view.fire( 'keydown', { keyCode: getCode( 'b' ) } );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevent from modifying document by `Input` feature when `InputCommand` is disabled. Closes #107.

---