### PR TITLE
Typing improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@ckeditor/ckeditor5-editor-classic": "^0.7.3",
     "@ckeditor/ckeditor5-enter": "^0.9.1",
     "@ckeditor/ckeditor5-heading": "^0.9.1",
+    "@ckeditor/ckeditor5-link": "^0.7.0",
     "@ckeditor/ckeditor5-paragraph": "^0.8.0",
     "@ckeditor/ckeditor5-undo": "^0.8.1",
     "@ckeditor/ckeditor5-presets": "^0.2.2",

--- a/src/input.js
+++ b/src/input.js
@@ -186,6 +186,10 @@ class MutationHandler {
 		// Get common ancestor in DOM.
 		const domMutationCommonAncestor = domConverter.mapViewToDom( mutationsCommonAncestor );
 
+		if ( !domMutationCommonAncestor ) {
+			return;
+		}
+
 		// Create fresh DomConverter so it will not use existing mapping and convert current DOM to model.
 		// This wouldn't be needed if DomConverter would allow to create fresh view without checking any mappings.
 		const freshDomConverter = new DomConverter();
@@ -207,6 +211,12 @@ class MutationHandler {
 		// See comment in `_handleTextMutation`.
 		const newText = modelFromDomChildren.map( item => item.data ).join( '' ).replace( /\u00A0/g, ' ' );
 		const oldText = currentModelChildren.map( item => item.data ).join( '' );
+
+		// Do nothing if mutations created same text.
+		if ( oldText === newText ) {
+			return;
+		}
+
 		const diffResult = diff( oldText, newText );
 
 		const { firstChangeAt, insertions, deletions } = calculateChanges( diffResult );

--- a/src/input.js
+++ b/src/input.js
@@ -291,11 +291,6 @@ class MutationHandler {
 		}
 
 		const change = getSingleTextNodeChange( mutation );
-
-		if ( !change ) {
-			return;
-		}
-
 		const viewPos = new ViewPosition( mutation.node, change.index );
 		const modelPos = this.editing.mapper.toModelPosition( viewPos );
 		const insertedText = change.values[ 0 ].data;
@@ -410,10 +405,6 @@ function getMutationsCommonAncestor( mutations ) {
 			return ancestors;
 		} ).filter( item => item !== shortestList );
 
-	if ( !shortestList ) {
-		return null;
-	}
-
 	// Find common ancestor from the lists. Go from the shortest list to the top. If common ancestor is found - return it.
 	for ( const ancestor of shortestList ) {
 		// Check only container and root elements.
@@ -448,7 +439,7 @@ function containerChildrenMutated( mutations ) {
 		return false;
 	}
 
-	// Check if all mutations are `children` type, and there is no single text node mutation
+	// Check if all mutations are `children` type, and there is no single text node mutation.
 	for ( const mutation of mutations ) {
 		if ( mutation.type !== 'children' || getSingleTextNodeChange( mutation ) ) {
 			return false;

--- a/src/input.js
+++ b/src/input.js
@@ -199,11 +199,11 @@ class MutationHandler {
 		const currentModel = this.editor.editing.mapper.toModelElement( mutationsCommonAncestor );
 
 		// Get children from both ancestors.
-		const modelFromDomChildren = [ ...modelFromCurrentDom.getChildren() ];
-		const currentModelChildren = [ ...currentModel.getChildren() ];
+		const modelFromDomChildren = Array.from( modelFromCurrentDom.getChildren() );
+		const currentModelChildren = Array.from( currentModel.getChildren() );
 
-		// Fix situations when common ancestor has only text nodes inside.
-		if ( !containsOnlyTextNodes( modelFromDomChildren ) || !containsOnlyTextNodes( currentModelChildren ) ) {
+		// Skip situations when common ancestor has any elements (cause they are too hard).
+		if ( !hasOnlyTextNodes( modelFromDomChildren ) || !hasOnlyTextNodes( currentModelChildren ) ) {
 			return;
 		}
 
@@ -451,16 +451,10 @@ function containerChildrenMutated( mutations ) {
 
 // Returns true if provided array contains only {@link module:engine/model/text~Text model text nodes}.
 //
-// @param {Array<module:engine/model/node~Node>} children
+// @param {Array.<module:engine/model/node~Node>} children
 // @returns {Boolean}
-function containsOnlyTextNodes( children ) {
-	for ( const child of children ) {
-		if ( !child.is( 'text' ) ) {
-			return false;
-		}
-	}
-
-	return true;
+function hasOnlyTextNodes( children ) {
+	return children.every( child => child.is( 'text' ) );
 }
 
 // Calculates first change index and number of characters that should be inserted and deleted starting from that index.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed a range of issues when typing or using a spellchecker on styled words leads to errors. Closes #100. Closes ckeditor/ckeditor5#491.

---

### Additional information
It also closes main issue reported in: https://github.com/ckeditor/ckeditor5/issues/491. Test case reported by @Reinmar https://github.com/ckeditor/ckeditor5/issues/491#issuecomment-312657159 looks like it's out of the scope of this issue - I've tested it a little and insertion to the model looks correct. It should be reported as separate ticket.

When this PR will be merged I'll create some follow ups:
 * issue about using new DomConverter instance, it is described also here: https://github.com/ckeditor/ckeditor5-engine/issues/993#issuecomment-315696765,
 * when auto correcting bolded word, that is placed at the end of the paragraph,  mutation of all paragraphs are fired, this should be handled separately,
 * selection is sometimes lost/in incorrect place when auto correcting bolded word, when output word is shorter than input one.


