### PR TITLE
T/61: Improved the typing when the whole content is selected

### DIFF
--- a/src/delete.js
+++ b/src/delete.js
@@ -34,7 +34,7 @@ export default class Delete extends Plugin {
 		editor.commands.add( 'delete', new DeleteCommand( editor, 'backward' ) );
 
 		this.listenTo( editingView, 'delete', ( evt, data ) => {
-			editor.execute( data.direction == 'forward' ? 'forwardDelete' : 'delete', { unit: data.unit } );
+			editor.execute( data.direction == 'forward' ? 'forwardDelete' : 'delete', { unit: data.unit, sequence: data.sequence } );
 			data.preventDefault();
 		} );
 	}

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -172,6 +172,6 @@ export default class DeleteCommand extends Command {
 		this._buffer.batch.remove( Range.createIn( limitElement ) );
 		this._buffer.batch.insert( Position.createAt( limitElement ), paragraph );
 
-		selection.collapse( paragraph );
+		selection.setCollapsedAt( paragraph );
 	}
 }

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -120,8 +120,8 @@ export default class DeleteCommand extends Command {
 	 * we want to replace the entire content with a paragraph if:
 	 *
 	 * * the current limit element is empty,
-	 * * the paragraph is allowed in the common ancestor,
-	 * * other paragraph does not occur in the editor.
+	 * * the paragraph is allowed in the limit element,
+	 * * other empty paragraph does not occur in the limit element.
 	 *
 	 * See https://github.com/ckeditor/ckeditor5-typing/issues/61.
 	 *
@@ -138,9 +138,10 @@ export default class DeleteCommand extends Command {
 		const document = this.editor.document;
 		const selection = document.selection;
 		const limitElement = document.schema.getLimitElement( selection );
+
 		// If a collapsed selection contains the whole content it means that the content is empty
 		// (from the user perspective).
-		const limitElementIsEmpty = selection.isCollapsed && selection.isEntireContentSelected( limitElement );
+		const limitElementIsEmpty = selection.isCollapsed && selection.containsEntireContent( limitElement );
 
 		if ( !limitElementIsEmpty ) {
 			return false;
@@ -150,8 +151,10 @@ export default class DeleteCommand extends Command {
 			return false;
 		}
 
-		// Does nothing if editor already contains an empty paragraph.
-		if ( selection.getFirstRange().getCommonAncestor().name === 'paragraph' ) {
+		const limitElementFirstChild = limitElement.getChild( 0 );
+
+		// Does nothing if limit element already contains an empty paragraph.
+		if ( limitElementFirstChild && limitElementFirstChild.name === 'paragraph' ) {
 			return false;
 		}
 

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -121,7 +121,7 @@ export default class DeleteCommand extends Command {
 	 *
 	 * * the current limit element is empty,
 	 * * the paragraph is allowed in the limit element,
-	 * * other empty paragraph does not occur in the limit element.
+	 * * the limit doesn't already have a paragraph inside.
 	 *
 	 * See https://github.com/ckeditor/ckeditor5-typing/issues/61.
 	 *
@@ -153,7 +153,9 @@ export default class DeleteCommand extends Command {
 
 		const limitElementFirstChild = limitElement.getChild( 0 );
 
-		// Does nothing if limit element already contains an empty paragraph.
+		// Does nothing if the limit element already contains only a paragraph.
+		// We ignore the case when paragraph might have some inline elements (<p><inlineWidget>[]</inlineWidget></p>)
+		// because we don't support such cases yet and it's unclear whether inlineWidget shouldn't be a limit itself.
 		if ( limitElementFirstChild && limitElementFirstChild.name === 'paragraph' ) {
 			return false;
 		}

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -131,7 +131,7 @@ export default class DeleteCommand extends Command {
 
 		const document = this.editor.document;
 		const selection = document.selection;
-		const limitElement = getLimitElement( document.schema, selection );
+		const limitElement = document.schema.getLimitElement( selection );
 		const limitStartPosition = Position.createAt( limitElement );
 		const limitEndPosition = Position.createAt( limitElement, 'end' );
 
@@ -162,7 +162,7 @@ export default class DeleteCommand extends Command {
 	_replaceEntireContentWithParagraph() {
 		const document = this.editor.document;
 		const selection = document.selection;
-		const limitElement = getLimitElement( document.schema, selection );
+		const limitElement = document.schema.getLimitElement( selection );
 		const paragraph = new Element( 'paragraph' );
 
 		this._buffer.batch.remove( Range.createIn( limitElement ) );
@@ -170,19 +170,4 @@ export default class DeleteCommand extends Command {
 
 		selection.collapse( paragraph );
 	}
-}
-
-// Returns the lowest limit element defined in `Schema.limits` for passed selection.
-function getLimitElement( schema, selection ) {
-	let element = selection.getFirstRange().getCommonAncestor();
-
-	while ( !schema.limits.has( element.name ) ) {
-		if ( element.parent ) {
-			element = element.parent;
-		} else {
-			break;
-		}
-	}
-
-	return element;
 }

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -9,6 +9,8 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
+import Element from '@ckeditor/ckeditor5-engine/src/model/element';
+import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 import Range from '@ckeditor/ckeditor5-engine/src/model/range';
 import ChangeBuffer from './changebuffer';
 import count from '@ckeditor/ckeditor5-utils/src/count';
@@ -106,11 +108,9 @@ export default class DeleteCommand extends Command {
 	 *
 	 * But, if the user pressed and released the key, we want to replace the entire content with a paragraph if:
 	 *
-	 *  * the entire content is selected,
-	 *  * the paragraph is allowed in the common ancestor,
-	 *  * other paragraph does not occur in the editor.
-	 *
-	 *  Rest of the checks are done in {@link module:engine/controller/datacontroller~DataController#deleteContent} method.
+	 * * the entire content is selected,
+	 * * the paragraph is allowed in the common ancestor,
+	 * * other paragraph does not occur in the editor.
 	 *
 	 * @private
 	 * @param {Number} sequence A number describing which subsequent delete event it is without the key being released.
@@ -124,10 +124,23 @@ export default class DeleteCommand extends Command {
 
 		const document = this.editor.document;
 		const selection = document.selection;
-		const commonAncestor = selection.getFirstRange().getCommonAncestor();
+		const limitElement = getLimitElement( document.schema, selection );
+		const limitStartPosition = Position.createAt( limitElement );
+		const limitEndPosition = Position.createAt( limitElement, 'end' );
+
+		if (
+			!limitStartPosition.isTouching( selection.getFirstPosition() ) ||
+			!limitEndPosition.isTouching( selection.getLastPosition() )
+		) {
+			return false;
+		}
+
+		if ( !document.schema.check( { name: 'paragraph', inside: limitElement.name } ) ) {
+			return false;
+		}
 
 		// Does nothing if editor already contains an empty paragraph.
-		if ( commonAncestor.name === 'paragraph' ) {
+		if ( selection.getFirstRange().getCommonAncestor().name === 'paragraph' ) {
 			return false;
 		}
 
@@ -140,13 +153,15 @@ export default class DeleteCommand extends Command {
 	 * @private
 	 */
 	_replaceEntireContentWithParagraph() {
-		const editor = this.editor;
-		const document = editor.document;
+		const document = this.editor.document;
 		const selection = document.selection;
 		const limitElement = getLimitElement( document.schema, selection );
+		const paragraph = new Element( 'paragraph' );
 
-		selection.setRanges( [ Range.createIn( limitElement ) ], selection.isBackward );
-		editor.data.deleteContent( selection, this._buffer.batch, { skipParentsCheck: true } );
+		this._buffer.batch.remove( Range.createIn( limitElement ) );
+		this._buffer.batch.insert( Position.createAt( limitElement ), paragraph );
+
+		selection.collapse( paragraph );
 	}
 }
 

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -132,13 +132,8 @@ export default class DeleteCommand extends Command {
 		const document = this.editor.document;
 		const selection = document.selection;
 		const limitElement = document.schema.getLimitElement( selection );
-		const limitStartPosition = Position.createAt( limitElement );
-		const limitEndPosition = Position.createAt( limitElement, 'end' );
 
-		if (
-			!limitStartPosition.isTouching( selection.getFirstPosition() ) ||
-			!limitEndPosition.isTouching( selection.getLastPosition() )
-		) {
+		if ( !selection.isEntireContentSelected( limitElement ) ) {
 			return false;
 		}
 

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -58,7 +58,8 @@ export default class DeleteCommand extends Command {
 	 * @fires execute
 	 * @param {Object} [options] The command options.
 	 * @param {'character'} [options.unit='character'] See {@link module:engine/controller/modifyselection~modifySelection}'s options.
-	 * @param {Number} [options.sequence=1] See the {@link module:engine/view/document~Document#event:delete} event data.
+	 * @param {Number} [options.sequence=1] A number describing which subsequent delete event it is without the key being released.
+	 * See the {@link module:engine/view/document~Document#event:delete} event data.
 	 */
 	execute( options = {} ) {
 		const doc = this.editor.document;
@@ -110,14 +111,17 @@ export default class DeleteCommand extends Command {
 	}
 
 	/**
-	 * If the user keeps <kbd>Backspace</kbd> or <kbd>Delete</kbd> key, we do nothing because the user can clear
-	 * the whole element without removing them.
+	 * If the user keeps <kbd>Backspace</kbd> or <kbd>Delete</kbd> key pressed, the content of the current
+	 * editable will be cleared. However, this will not yet lead to resetting the remaining block to a paragraph
+	 * (which happens e.g. when the user does <kbd>Ctrl</kbd> + <kbd>A</kbd>, <kbd>Backspace</kbd>).
 	 *
-	 * But, if the user pressed and released the key, we want to replace the entire content with a paragraph if:
+	 * But, if the user pressed the key again, we want to replace the entire content with a paragraph if:
 	 *
 	 * * the entire content is selected,
 	 * * the paragraph is allowed in the common ancestor,
 	 * * other paragraph does not occur in the editor.
+	 *
+	 * See https://github.com/ckeditor/ckeditor5-typing/issues/61.
 	 *
 	 * @private
 	 * @param {Number} sequence A number describing which subsequent delete event it is without the key being released.

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -112,8 +112,7 @@ export default class DeleteCommand extends Command {
 	 *   - other paragraph does not occur in the editor.
 	 *
 	 * @private
-	 * @param {Object} options
-	 * @param {Number} options.sequence A number that describes which sequence of the same event is fired.
+	 * @param {Number} sequence A number describing which subsequent delete event it is without the key being released.
 	 * @returns {Boolean}
 	 */
 	_shouldEntireContentBeReplacedWithParagraph( options ) {

--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -78,7 +78,7 @@ export default class DeleteCommand extends Command {
 			if ( selection.isCollapsed ) {
 				const sequence = options.sequence || 1;
 
-				if ( this._shouldEntireContentBeReplacedWithParagraph( { sequence } ) ) {
+				if ( this._shouldEntireContentBeReplacedWithParagraph( sequence ) ) {
 					this._replaceEntireContentWithParagraph();
 				}
 
@@ -115,9 +115,9 @@ export default class DeleteCommand extends Command {
 	 * @param {Number} sequence A number describing which subsequent delete event it is without the key being released.
 	 * @returns {Boolean}
 	 */
-	_shouldEntireContentBeReplacedWithParagraph( options ) {
+	_shouldEntireContentBeReplacedWithParagraph( sequence ) {
 		// Does nothing if user pressed and held the "Backspace" or "Delete" key.
-		if ( options.sequence > 1 ) {
+		if ( sequence > 1 ) {
 			return false;
 		}
 

--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -20,6 +20,14 @@ export default class DeleteObserver extends Observer {
 	constructor( document ) {
 		super( document );
 
+		let sequence = 0;
+
+		document.on( 'keyup', ( evt, data ) => {
+			if ( data.keyCode == keyCodes.delete || data.keyCode == keyCodes.backspace ) {
+				sequence = 0;
+			}
+		} );
+
 		document.on( 'keydown', ( evt, data ) => {
 			const deleteData = {};
 
@@ -34,6 +42,7 @@ export default class DeleteObserver extends Observer {
 			}
 
 			deleteData.unit = data.altKey ? 'word' : deleteData.unit;
+			deleteData.sequence = ++sequence;
 
 			document.fire( 'delete', new DomEventData( document, data.domEvent, deleteData ) );
 		} );
@@ -55,4 +64,6 @@ export default class DeleteObserver extends Observer {
  * @param {module:engine/view/observer/domeventdata~DomEventData} data
  * @param {'forward'|'delete'} data.direction The direction in which the deletion should happen.
  * @param {'character'|'word'} data.unit The "amount" of content that should be deleted.
+ * @param {Number} data.sequence A number that describes which sequence of the same event is fired.
+ * It helps detect the key was pressed and held.
  */

--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -64,6 +64,6 @@ export default class DeleteObserver extends Observer {
  * @param {module:engine/view/observer/domeventdata~DomEventData} data
  * @param {'forward'|'delete'} data.direction The direction in which the deletion should happen.
  * @param {'character'|'word'} data.unit The "amount" of content that should be deleted.
- * @param {Number} data.sequence A number that describes which sequence of the same event is fired.
- * It helps detect the key was pressed and held.
+ * @param {Number} data.sequence A number describing which subsequent delete event it is without the key being released.
+ * If it's 2 or more it means that the key was pressed and hold.
  */

--- a/tests/delete.js
+++ b/tests/delete.js
@@ -34,21 +34,23 @@ describe( 'Delete feature', () => {
 
 		view.fire( 'delete', new DomEventData( editingView, domEvt, {
 			direction: 'forward',
-			unit: 'character'
+			unit: 'character',
+			sequence: 1
 		} ) );
 
 		expect( spy.calledOnce ).to.be.true;
-		expect( spy.calledWithMatch( 'forwardDelete', { unit: 'character' } ) ).to.be.true;
+		expect( spy.calledWithMatch( 'forwardDelete', { unit: 'character', sequence: 1 } ) ).to.be.true;
 
 		expect( domEvt.preventDefault.calledOnce ).to.be.true;
 
 		view.fire( 'delete', new DomEventData( editingView, getDomEvent(), {
 			direction: 'backward',
-			unit: 'character'
+			unit: 'character',
+			sequence: 5
 		} ) );
 
 		expect( spy.calledTwice ).to.be.true;
-		expect( spy.calledWithMatch( 'delete', { unit: 'character' } ) ).to.be.true;
+		expect( spy.calledWithMatch( 'delete', { unit: 'character', sequence: 5 } ) ).to.be.true;
 	} );
 
 	function getDomEvent() {

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -147,7 +147,7 @@ describe( 'DeleteCommand', () => {
 
 			editor.execute( 'delete' );
 
-			expect( getData( doc, { selection: true } ) ).to.equal( '<paragraph>[]</paragraph>' );
+			expect( getData( doc ) ).to.equal( '<paragraph>[]</paragraph>' );
 		} );
 
 		it( 'leaves an empty paragraph after removing the whole content inside limit element', () => {
@@ -157,22 +157,38 @@ describe( 'DeleteCommand', () => {
 
 			setData( doc,
 				'<heading1>Foo</heading1>' +
-				'<section>' +
-				'<heading1>[Header 1</heading1>' +
-				'<paragraph>Some text.]</paragraph>' +
-				'</section>' +
+					'<section>' +
+						'<heading1>[Header 1</heading1>' +
+						'<paragraph>Some text.]</paragraph>' +
+					'</section>' +
 				'<paragraph>Bar.</paragraph>'
 			);
 
 			editor.execute( 'delete' );
 
-			expect( getData( doc, { selection: true } ) ).to.equal(
+			expect( getData( doc ) ).to.equal(
 				'<heading1>Foo</heading1>' +
 				'<section>' +
-				'<paragraph>[]</paragraph>' +
+					'<paragraph>[]</paragraph>' +
 				'</section>' +
 				'<paragraph>Bar.</paragraph>'
 			);
+		} );
+
+		it( 'leaves an empty paragraph after removing another paragraph from block element', () => {
+			doc.schema.registerItem( 'section', '$block' );
+			doc.schema.registerItem( 'blockQuote', '$block' );
+			doc.schema.limits.add( 'section' );
+			doc.schema.allow( { name: 'section', inside: '$root' } );
+			doc.schema.allow( { name: 'paragraph', inside: 'section' } );
+			doc.schema.allow( { name: 'blockQuote', inside: 'section' } );
+			doc.schema.allow( { name: 'paragraph', inside: 'blockQuote' } );
+
+			setData( doc, '<section><blockQuote><paragraph>[]</paragraph></blockQuote></section>' );
+
+			editor.execute( 'delete' );
+
+			expect( getData( doc ) ).to.equal( '<section><paragraph>[]</paragraph></section>' );
 		} );
 
 		it( 'leaves an empty paragraph after removing the whole content when root element was not added as Schema.limits', () => {
@@ -190,7 +206,7 @@ describe( 'DeleteCommand', () => {
 
 			editor.execute( 'delete' );
 
-			expect( getData( doc, { selection: true } ) ).to.equal( '<paragraph>[]</paragraph>' );
+			expect( getData( doc ) ).to.equal( '<paragraph>[]</paragraph>' );
 		} );
 
 		it( 'does not replace an element when Backspace or Delete key is held', () => {
@@ -200,17 +216,17 @@ describe( 'DeleteCommand', () => {
 				editor.execute( 'delete', { sequence } );
 			}
 
-			expect( getData( doc, { selection: true } ) ).to.equal( '<heading1>[]</heading1>' );
+			expect( getData( doc ) ).to.equal( '<heading1>[]</heading1>' );
 		} );
 
-		it( 'does not replace an element if a paragraph is a common ancestor', () => {
+		it( 'does not replace with paragraph in another paragraph already occurs in limit element', () => {
 			setData( doc, '<paragraph>[]</paragraph>' );
 
-			const element = doc.selection.getFirstRange().getCommonAncestor();
+			const element = doc.getRoot().getNodeByPath( [ 0 ] );
 
 			editor.execute( 'delete' );
 
-			expect( element ).is.equal( doc.selection.getFirstRange().getCommonAncestor() );
+			expect( element ).is.equal( doc.getRoot().getNodeByPath( [ 0 ] ) );
 		} );
 
 		it( 'does not replace an element if a paragraph is not allowed in current position', () => {
@@ -221,7 +237,7 @@ describe( 'DeleteCommand', () => {
 			editor.execute( 'delete' );
 
 			// Returned data: '[]' instead of the heading element.
-			expect( getData( doc, { selection: true } ) ).to.equal( '<heading1>[]</heading1>' );
+			expect( getData( doc ) ).to.equal( '<heading1>[]</heading1>' );
 		} );
 	} );
 } );

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -185,13 +185,14 @@ describe( 'DeleteCommand', () => {
 			expect( element ).is.equal( doc.selection.getFirstRange().getCommonAncestor() );
 		} );
 
-		it( 'does not replace an element if a paragraph is not allowed in current position', () => {
+		xit( 'does not replace an element if a paragraph is not allowed in current position', () => {
 			doc.schema.disallow( { name: 'paragraph', inside: '$root' } );
 
 			setData( doc, '<heading1>[]</heading1>' );
 
 			editor.execute( 'delete' );
 
+			// Returned data: '[]' instead of the heading element.
 			expect( getData( doc, { selection: true } ) ).to.equal( '<heading1>[]</heading1>' );
 		} );
 	} );

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -66,7 +66,7 @@ describe( 'DeleteCommand', () => {
 
 			editor.execute( 'delete' );
 
-			expect( getData( doc, { selection: true } ) ).to.equal( '<paragraph>fo[]bar</paragraph>' );
+			expect( getData( doc ) ).to.equal( '<paragraph>fo[]bar</paragraph>' );
 		} );
 
 		it( 'deletes selection contents', () => {
@@ -74,7 +74,7 @@ describe( 'DeleteCommand', () => {
 
 			editor.execute( 'delete' );
 
-			expect( getData( doc, { selection: true } ) ).to.equal( '<paragraph>fo[]ar</paragraph>' );
+			expect( getData( doc ) ).to.equal( '<paragraph>fo[]ar</paragraph>' );
 		} );
 
 		it( 'merges elements', () => {
@@ -82,7 +82,7 @@ describe( 'DeleteCommand', () => {
 
 			editor.execute( 'delete' );
 
-			expect( getData( doc, { selection: true } ) ).to.equal( '<paragraph>foo[]bar</paragraph>' );
+			expect( getData( doc ) ).to.equal( '<paragraph>foo[]bar</paragraph>' );
 		} );
 
 		it( 'does not try to delete when selection is at the boundary', () => {
@@ -93,7 +93,7 @@ describe( 'DeleteCommand', () => {
 
 			editor.execute( 'delete' );
 
-			expect( getData( doc, { selection: true } ) ).to.equal( '<paragraph>[]foo</paragraph>' );
+			expect( getData( doc ) ).to.equal( '<paragraph>[]foo</paragraph>' );
 			expect( spy.callCount ).to.equal( 0 );
 		} );
 

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -236,7 +236,6 @@ describe( 'DeleteCommand', () => {
 
 			editor.execute( 'delete' );
 
-			// Returned data: '[]' instead of the heading element.
 			expect( getData( doc ) ).to.equal( '<heading1>[]</heading1>' );
 		} );
 	} );

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -46,11 +46,11 @@ describe( 'DeleteCommand', () => {
 
 				// We expect that command is executed in enqueue changes block. Since we are already in
 				// an enqueued block, the command execution will be postponed. Hence, no changes.
-				expect( getData( doc ) ).to.equal( '<p>foo[]bar</p>' );
+				expect( getData( doc ) ).to.equal( '<paragraph>foo[]bar</paragraph>' );
 			} );
 
 			// After all enqueued changes are done, the command execution is reflected.
-			expect( getData( doc ) ).to.equal( '<p>fo[]bar</p>' );
+			expect( getData( doc ) ).to.equal( '<paragraph>fo[]bar</paragraph>' );
 		} );
 
 		it( 'locks buffer when executing', () => {

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -185,7 +185,7 @@ describe( 'DeleteCommand', () => {
 			expect( element ).is.equal( doc.selection.getFirstRange().getCommonAncestor() );
 		} );
 
-		xit( 'does not replace an element if a paragraph is not allowed in current position', () => {
+		it( 'does not replace an element if a paragraph is not allowed in current position', () => {
 			doc.schema.disallow( { name: 'paragraph', inside: '$root' } );
 
 			setData( doc, '<heading1>[]</heading1>' );

--- a/tests/deleteobserver.js
+++ b/tests/deleteobserver.js
@@ -40,6 +40,7 @@ describe( 'DeleteObserver', () => {
 			const data = spy.args[ 0 ][ 1 ];
 			expect( data ).to.have.property( 'direction', 'forward' );
 			expect( data ).to.have.property( 'unit', 'character' );
+			expect( data ).to.have.property( 'sequence', 1 );
 		} );
 
 		it( 'is fired with a proper direction and unit', () => {
@@ -57,6 +58,7 @@ describe( 'DeleteObserver', () => {
 			const data = spy.args[ 0 ][ 1 ];
 			expect( data ).to.have.property( 'direction', 'backward' );
 			expect( data ).to.have.property( 'unit', 'word' );
+			expect( data ).to.have.property( 'sequence', 1 );
 		} );
 
 		it( 'is not fired on keydown when keyCode does not match backspace or delete', () => {
@@ -69,6 +71,101 @@ describe( 'DeleteObserver', () => {
 			} ) );
 
 			expect( spy.calledOnce ).to.be.false;
+		} );
+
+		it( 'is fired with a proper sequence number', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'delete', spy );
+
+			// Simulate that a user keeps the "Delete" key.
+			for ( let i = 0; i < 5; ++i ) {
+				viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+					keyCode: getCode( 'delete' )
+				} ) );
+			}
+
+			expect( spy.callCount ).to.equal( 5 );
+
+			expect( spy.args[ 0 ][ 1 ] ).to.have.property( 'sequence', 1 );
+			expect( spy.args[ 1 ][ 1 ] ).to.have.property( 'sequence', 2 );
+			expect( spy.args[ 2 ][ 1 ] ).to.have.property( 'sequence', 3 );
+			expect( spy.args[ 3 ][ 1 ] ).to.have.property( 'sequence', 4 );
+			expect( spy.args[ 4 ][ 1 ] ).to.have.property( 'sequence', 5 );
+		} );
+
+		it( 'clears the sequence when the key was released', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'delete', spy );
+
+			// Simulate that a user keeps the "Delete" key.
+			for ( let i = 0; i < 3; ++i ) {
+				viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+					keyCode: getCode( 'delete' )
+				} ) );
+			}
+
+			// Then the user has released the key.
+			viewDocument.fire( 'keyup', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'delete' )
+			} ) );
+
+			// And pressed it once again.
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'delete' )
+			} ) );
+
+			expect( spy.callCount ).to.equal( 4 );
+
+			expect( spy.args[ 0 ][ 1 ] ).to.have.property( 'sequence', 1 );
+			expect( spy.args[ 1 ][ 1 ] ).to.have.property( 'sequence', 2 );
+			expect( spy.args[ 2 ][ 1 ] ).to.have.property( 'sequence', 3 );
+			expect( spy.args[ 3 ][ 1 ] ).to.have.property( 'sequence', 1 );
+		} );
+
+		it( 'works fine with Backspace key', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'delete', spy );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'backspace' )
+			} ) );
+
+			viewDocument.fire( 'keyup', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'backspace' )
+			} ) );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'backspace' )
+			} ) );
+
+			expect( spy.callCount ).to.equal( 2 );
+
+			expect( spy.args[ 0 ][ 1 ] ).to.have.property( 'sequence', 1 );
+			expect( spy.args[ 1 ][ 1 ] ).to.have.property( 'sequence', 1 );
+		} );
+
+		it( 'does not reset the sequence if other than Backspace or Delete key was released', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'delete', spy );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'delete' )
+			} ) );
+
+			viewDocument.fire( 'keyup', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'A' )
+			} ) );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'delete' )
+			} ) );
+
+			expect( spy.args[ 0 ][ 1 ] ).to.have.property( 'sequence', 1 );
+			expect( spy.args[ 1 ][ 1 ] ).to.have.property( 'sequence', 2 );
 		} );
 	} );
 

--- a/tests/manual/delete.md
+++ b/tests/manual/delete.md
@@ -4,7 +4,7 @@ Check:
 
 * collapsed selection (by letter, by word, whole line),
 * non-collapsed selections,
-* put the selection at the end of **Heading 1**, **press and hold** the Backspace. 
+* put the selection at the end of **Heading 1**, **press and hold** the Backspace.
 After releasing the key you should be able typing inside the header.
 * clear the whole editor and choose **Heading 1** from the dropdown. Press the Backspace.
-After typing, your text should be wrapped in a paragraph.  
+After typing, your text should be wrapped in a paragraph.

--- a/tests/manual/delete.md
+++ b/tests/manual/delete.md
@@ -3,4 +3,8 @@
 Check:
 
 * collapsed selection (by letter, by word, whole line),
-* non-collapsed selections.
+* non-collapsed selections,
+* put the selection at the end of **Heading 1**, **press and hold** the Backspace. 
+After releasing the key you should be able typing inside the header.
+* clear the whole editor and choose **Heading 1** from the dropdown. Press the Backspace.
+After typing, your text should be wrapped in a paragraph.  

--- a/tests/manual/input.md
+++ b/tests/manual/input.md
@@ -4,7 +4,7 @@ Check:
 
 * normal typing,
 * typing into non-collapsed selection,
-* typing when the entire content is selected - new content should be wrapped in a paragraph. 
+* typing when the entire content is selected - new content should be wrapped in a paragraph.
 
 ### IME
 

--- a/tests/manual/input.md
+++ b/tests/manual/input.md
@@ -3,7 +3,8 @@
 Check:
 
 * normal typing,
-* typing into non-collapsed selection.
+* typing into non-collapsed selection,
+* typing when the entire content is selected - new content should be wrapped in a paragraph. 
 
 ### IME
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Improved the typing when the whole content is selected. Closes #61.
* After typing when the entire content was selected – text will be wrapped in the paragraph.
* In an empty editor – press and hold the Backspace key will not remove styles of the current element. The entire content will be removed but the element will left.