### PR TITLE
Added: Used doNotResetEntireContent flag of DataController#deleteContent().

### DIFF
--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -66,6 +66,13 @@ export default class DeleteCommand extends Command {
 
 			const selection = Selection.createFromSelection( doc.selection );
 
+			// Do not replace the whole selected content if selection was collapsed.
+			// This prevents such situation:
+			//
+			// <h1></h1><p>[]</p>	-->  <h1>[</h1><p>]</p> 		-->  <p></p>
+			// starting content		-->   after `modifySelection`	-->  after `deleteContent`.
+			const doNotResetEntireContent = selection.isCollapsed;
+
 			// Try to extend the selection in the specified direction.
 			if ( selection.isCollapsed ) {
 				dataController.modifySelection( selection, { direction: this.direction, unit: options.unit } );
@@ -84,7 +91,7 @@ export default class DeleteCommand extends Command {
 				);
 			} );
 
-			dataController.deleteContent( selection, this._buffer.batch );
+			dataController.deleteContent( selection, this._buffer.batch, { doNotResetEntireContent } );
 			this._buffer.input( changeCount );
 
 			doc.selection.setRanges( selection.getRanges(), selection.isBackward );

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -112,5 +112,33 @@ describe( 'DeleteCommand', () => {
 			expect( modifyOpts ).to.have.property( 'direction', 'forward' );
 			expect( modifyOpts ).to.have.property( 'unit', 'word' );
 		} );
+
+		it( 'passes options to deleteContent #1', () => {
+			const spy = sinon.spy();
+
+			editor.data.on( 'deleteContent', spy );
+			setData( doc, '<p>foo[]bar</p>' );
+
+			editor.execute( 'delete' );
+
+			expect( spy.callCount ).to.equal( 1 );
+
+			const deleteOpts = spy.args[ 0 ][ 1 ][ 2 ];
+			expect( deleteOpts ).to.have.property( 'doNotResetEntireContent', true );
+		} );
+
+		it( 'passes options to deleteContent #2', () => {
+			const spy = sinon.spy();
+
+			editor.data.on( 'deleteContent', spy );
+			setData( doc, '<p>[foobar]</p>' );
+
+			editor.execute( 'delete' );
+
+			expect( spy.callCount ).to.equal( 1 );
+
+			const deleteOpts = spy.args[ 0 ][ 1 ][ 2 ];
+			expect( deleteOpts ).to.have.property( 'doNotResetEntireContent', false );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fixed: Fixed a bug when editor content was incorrectly replaced with a new `<p>` if editor had two empty elements and `DeleteCommand` was used. Closes #113.