### PR TITLE
InputCommand should not create empty insert deltas

### DIFF
--- a/src/inputcommand.js
+++ b/src/inputcommand.js
@@ -84,7 +84,9 @@ export default class InputCommand extends Command {
 				this._buffer.batch.remove( range );
 			}
 
-			this._buffer.batch.weakInsert( range.start, text );
+			if ( text ) {
+				this._buffer.batch.weakInsert( range.start, text );
+			}
 
 			if ( resultRange ) {
 				this.editor.data.model.selection.setRanges( [ resultRange ] );

--- a/tests/inputcommand.js
+++ b/tests/inputcommand.js
@@ -216,6 +216,16 @@ describe( 'InputCommand', () => {
 			expect( getData( doc, { selection: true } ) ).to.be.equal( '<p>fo[]obar</p>' );
 			expect( buffer.size ).to.be.equal( 0 );
 		} );
+
+		it( 'does not create insert delta when no text given', () => {
+			setData( doc, '<p>foo[]bar</p>' );
+
+			const version = doc.version;
+
+			editor.execute( 'input' );
+
+			expect( doc.version ).to.equal( version );
+		} );
 	} );
 
 	describe( 'destroy', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed a bug where using spellchecker sometimes caused creating incorrect deltas, which caused bugs in undo. Closes #123. Closes https://github.com/ckeditor/ckeditor5-engine/issues/1152#event-1271895283.