### PR TITLE
Changed the way DeleteObserver handles keydown event

### DIFF
--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -31,6 +31,12 @@ export default class DeleteObserver extends Observer {
 		document.on( 'keydown', ( evt, data ) => {
 			const deleteData = {};
 
+			// Do not handle if specific event like `keydown:delete` is fired.
+			// https://github.com/ckeditor/ckeditor5/issues/753
+			if ( evt.name !== 'keydown' ) {
+				return;
+			}
+
 			if ( data.keyCode == keyCodes.delete ) {
 				deleteData.direction = 'forward';
 				deleteData.unit = 'character';
@@ -45,7 +51,11 @@ export default class DeleteObserver extends Observer {
 			deleteData.sequence = ++sequence;
 
 			document.fire( 'delete', new DomEventData( document, data.domEvent, deleteData ) );
-		} );
+
+			// Stop generic `keydown` event and fire specific `keydown:delete` event.
+			evt.stop();
+			document.fire( 'keydown:delete', data );
+		}, { priority: 'highest' } );
 	}
 
 	/**

--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -77,3 +77,13 @@ export default class DeleteObserver extends Observer {
  * @param {Number} data.sequence A number describing which subsequent delete event it is without the key being released.
  * If it's 2 or more it means that the key was pressed and hold.
  */
+
+/**
+ * Fired when a keydown event was handled by {@link module:typing/deleteobserver~DeleteObserver}.
+ * It can be used to determine if the event was handled by {@link module:typing/deleteobserver~DeleteObserver} or it is
+ * a generic event created by {@link module:engine/view/observer/keyobserver~KeyObserver}.
+ *
+ * @see module:engine/view/observer/keyobserver~KeyObserver
+ * @event module:engine/view/document~Document#event:keydown:delete
+ * @param {module:engine/view/observer/keyobserver~KeyEventData} keyEventData
+ */

--- a/src/input.js
+++ b/src/input.js
@@ -43,6 +43,12 @@ export default class Input extends Plugin {
 		editor.commands.add( 'input', inputCommand );
 
 		this.listenTo( editingView, 'keydown', ( evt, data ) => {
+			// Do not handle if specific event like `keydown:delete` or `keydown:enter` is fired.
+			// https://github.com/ckeditor/ckeditor5/issues/753
+			if ( evt.name !== 'keydown' ) {
+				return;
+			}
+
 			this._handleKeydown( data, inputCommand );
 		}, { priority: 'lowest' } );
 

--- a/tests/input.js
+++ b/tests/input.js
@@ -26,7 +26,7 @@ import ViewSelection from '@ckeditor/ckeditor5-engine/src/view/selection';
 import MutationObserver from '@ckeditor/ckeditor5-engine/src/view/observer/mutationobserver';
 
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import { getCode, keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
@@ -615,6 +615,13 @@ describe( 'Input feature', () => {
 			view.fire( 'keydown', { keyCode: getCode( 'b' ) } );
 
 			expect( getModelData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
+		} );
+
+		it( 'should not handle specific events like keydown:abc', () => {
+			setModelData( model, '<paragraph>f[ooba]r</paragraph>' );
+			view.fire( 'keydown:abc', { keyCode: keyCodes.delete } );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>f[ooba]r</paragraph>' );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `DeleteObserver` is now stopping generic `keydown` event when handling <kbd>Delete</kbd> and <kbd>Backspace</kbd> keys. It fires specific `keydown:delete` event instead. Closes https://github.com/ckeditor/ckeditor5/issues/753.

---
Please close together with: https://github.com/ckeditor/ckeditor5-enter/pull/50.


  