### PR TITLE
DeleteObserver cancells keydown event when delete event is cancelled.

### DIFF
--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -44,7 +44,17 @@ export default class DeleteObserver extends Observer {
 			deleteData.unit = data.altKey ? 'word' : deleteData.unit;
 			deleteData.sequence = ++sequence;
 
+			// Save the event object to check later if it was stopped or not.
+			let event;
+			document.once( 'delete', evt => ( event = evt ), { priority: 'highest' } );
+
 			document.fire( 'delete', new DomEventData( document, data.domEvent, deleteData ) );
+
+			// Stop `keydown` event if `delete` event was stopped.
+			// https://github.com/ckeditor/ckeditor5/issues/753
+			if ( event && event.stop.called ) {
+				evt.stop();
+			}
 		} );
 	}
 

--- a/tests/deleteobserver.js
+++ b/tests/deleteobserver.js
@@ -167,6 +167,30 @@ describe( 'DeleteObserver', () => {
 			expect( spy.args[ 0 ][ 1 ] ).to.have.property( 'sequence', 1 );
 			expect( spy.args[ 1 ][ 1 ] ).to.have.property( 'sequence', 2 );
 		} );
+
+		it( 'should stop keydown event when delete event is stopped', () => {
+			const keydownSpy = sinon.spy();
+			viewDocument.on( 'keydown', keydownSpy );
+			viewDocument.on( 'delete', evt => evt.stop() );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'delete' )
+			} ) );
+
+			sinon.assert.notCalled( keydownSpy );
+		} );
+
+		it( 'should not stop keydown event when delete event is not stopped', () => {
+			const keydownSpy = sinon.spy();
+			viewDocument.on( 'keydown', keydownSpy );
+			viewDocument.on( 'delete', evt => evt.stop() );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'x' )
+			} ) );
+
+			sinon.assert.calledOnce( keydownSpy );
+		} );
 	} );
 
 	function getDomEvent() {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `DeleteObserver` stops `keydown` event when `delete` event is stopped. Closes: https://github.com/ckeditor/ckeditor5/issues/753.

---
Please close together with: https://github.com/ckeditor/ckeditor5-enter/pull/51.

  