### PR TITLE
Added: Properly discover delete-word keyboard modifier on mac and non-mac computers.

### DIFF
--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -10,6 +10,7 @@
 import Observer from '@ckeditor/ckeditor5-engine/src/view/observer/observer';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 /**
  * Delete observer introduces the {@link module:engine/view/document~Document#event:delete} event.
@@ -41,7 +42,8 @@ export default class DeleteObserver extends Observer {
 				return;
 			}
 
-			deleteData.unit = data.altKey ? 'word' : deleteData.unit;
+			const hasWordModifier = env.isMac ? data.altKey : data.ctrlKey;
+			deleteData.unit = hasWordModifier ? 'word' : deleteData.unit;
 			deleteData.sequence = ++sequence;
 
 			// Save the event object to check later if it was stopped or not.

--- a/tests/deleteobserver.js
+++ b/tests/deleteobserver.js
@@ -12,6 +12,10 @@ import createViewRoot from '@ckeditor/ckeditor5-engine/tests/view/_utils/creater
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import env from '@ckeditor/ckeditor5-utils/src/env';
 
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+
+testUtils.createSinonSandbox();
+
 describe( 'DeleteObserver', () => {
 	let viewDocument;
 
@@ -29,12 +33,6 @@ describe( 'DeleteObserver', () => {
 	} );
 
 	describe( 'delete event', () => {
-		const initialEnvMac = env.isMac;
-
-		afterEach( () => {
-			env.isMac = initialEnvMac;
-		} );
-
 		it( 'is fired on keydown', () => {
 			const spy = sinon.spy();
 
@@ -55,7 +53,7 @@ describe( 'DeleteObserver', () => {
 		it( 'is fired with a proper direction and unit (on Mac)', () => {
 			const spy = sinon.spy();
 
-			env.isMac = true;
+			testUtils.sinon.stub( env, 'isMac' ).value( true );
 
 			viewDocument.on( 'delete', spy );
 
@@ -75,7 +73,7 @@ describe( 'DeleteObserver', () => {
 		it( 'is fired with a proper direction and unit (on non-Mac)', () => {
 			const spy = sinon.spy();
 
-			env.isMac = false;
+			testUtils.sinon.stub( env, 'isMac' ).value( false );
 
 			viewDocument.on( 'delete', spy );
 

--- a/tests/deleteobserver.js
+++ b/tests/deleteobserver.js
@@ -10,6 +10,7 @@ import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import createViewRoot from '@ckeditor/ckeditor5-engine/tests/view/_utils/createroot';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import env from '../../ckeditor5-utils/src/env';
 
 describe( 'DeleteObserver', () => {
 	let viewDocument;
@@ -28,6 +29,12 @@ describe( 'DeleteObserver', () => {
 	} );
 
 	describe( 'delete event', () => {
+		const initialEnvMac = env.isMac;
+
+		afterEach( () => {
+			env.isMac = initialEnvMac;
+		} );
+
 		it( 'is fired on keydown', () => {
 			const spy = sinon.spy();
 
@@ -45,14 +52,36 @@ describe( 'DeleteObserver', () => {
 			expect( data ).to.have.property( 'sequence', 1 );
 		} );
 
-		it( 'is fired with a proper direction and unit', () => {
+		it( 'is fired with a proper direction and unit (on Mac)', () => {
 			const spy = sinon.spy();
+
+			env.isMac = true;
 
 			viewDocument.on( 'delete', spy );
 
 			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
 				keyCode: getCode( 'backspace' ),
 				altKey: true
+			} ) );
+
+			expect( spy.calledOnce ).to.be.true;
+
+			const data = spy.args[ 0 ][ 1 ];
+			expect( data ).to.have.property( 'direction', 'backward' );
+			expect( data ).to.have.property( 'unit', 'word' );
+			expect( data ).to.have.property( 'sequence', 1 );
+		} );
+
+		it( 'is fired with a proper direction and unit (on non-Mac)', () => {
+			const spy = sinon.spy();
+
+			env.isMac = false;
+
+			viewDocument.on( 'delete', spy );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'backspace' ),
+				ctrlKey: true
 			} ) );
 
 			expect( spy.calledOnce ).to.be.true;

--- a/tests/deleteobserver.js
+++ b/tests/deleteobserver.js
@@ -10,7 +10,7 @@ import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import createViewRoot from '@ckeditor/ckeditor5-engine/tests/view/_utils/createroot';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
-import env from '../../ckeditor5-utils/src/env';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 describe( 'DeleteObserver', () => {
 	let viewDocument;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Properly discover delete-word keyboard modifier on mac and non-mac computers. Closes #92.

---

### Additional information

* Requires changes from https://github.com/ckeditor/ckeditor5-engine/pull/1287
