### PR TITLE
Bogus <br /> handling during typing

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -211,8 +211,8 @@ class MutationHandler {
 		const modelFromDomChildren = Array.from( modelFromCurrentDom.getChildren() );
 		const currentModelChildren = Array.from( currentModel.getChildren() );
 
-		// Remove the last `<softBreak>` from the end of the `modelFromDomChildren` if there is no `<softBreak>` current model.
-		// If that happened, it means that this is a bogus br added by a browser.
+		// Remove the last `<softBreak>` from the end of `modelFromDomChildren` if there is no `<softBreak>` in current model.
+		// If the described scenario happened, it means that this is a bogus `<br />` added by a browser.
 		const lastDomChild = modelFromDomChildren[ modelFromDomChildren.length - 1 ];
 		const lastCurrentChild = currentModelChildren[ currentModelChildren.length - 1 ];
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Bogus `<br />` element inserted by a browser at the end of an element is now correctly handled. Closes https://github.com/ckeditor/ckeditor5/issues/1083.

---

### Additional information

This is not a complete solution. I don't like two things:

* Inserting `@` in place of non-text elements. I tested it manually and it looks like everything works well but I am a little skeptical because a user may type `@` by themselves and I am afraid it may mess up the diff. Still, I tried putting `<br />` between typed `@`s and it worked 🤷‍♂️ .
* Only `<softBreak>` "inline" element is now supported. I wanted to do it in a future-proof way but I don't know how you can differentiate that given elements are "inline" elements (like `<softBreak>`). Basically, when we will introduce a new inline element, like smileys or maybe placeholders, we again will have a problem in `isSafeForTextMutation` function. Maybe we could introduce `isInline` flag in `SchemaItemDefinition`?
