### PR TITLE
Handling &nbsp; in mutations

### DIFF
--- a/src/utils/injecttypingmutationshandling.js
+++ b/src/utils/injecttypingmutationshandling.js
@@ -148,7 +148,7 @@ class MutationHandler {
 		// that we need to take care of proper indexes so we cannot simply remove non-text elements from the content.
 		// By inserting a character we keep all the real texts on their indexes.
 		const newText = modelFromDomChildren.map( item => item.is( 'text' ) ? item.data : '@' ).join( '' ).replace( /\u00A0/g, ' ' );
-		const oldText = currentModelChildren.map( item => item.is( 'text' ) ? item.data : '@' ).join( '' );
+		const oldText = currentModelChildren.map( item => item.is( 'text' ) ? item.data : '@' ).join( '' ).replace( /\u00A0/g, ' ' );
 
 		// Do nothing if mutations created same text.
 		if ( oldText === newText ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `&nbsp;` is now correctly handled in mutations. Closes #170.