### PR TITLE
Suggestion mode improvements

### DIFF
--- a/src/deletecommand.js
+++ b/src/deletecommand.js
@@ -49,6 +49,15 @@ export default class DeleteCommand extends Command {
 	}
 
 	/**
+	 * The current change buffer.
+	 *
+	 * @type {module:typing/utils/changebuffer~ChangeBuffer}
+	 */
+	get buffer() {
+		return this._buffer;
+	}
+
+	/**
 	 * Executes the delete command. Depending on whether the selection is collapsed or not, deletes its content
 	 * or a piece of content in the {@link #direction defined direction}.
 	 *

--- a/src/inputcommand.js
+++ b/src/inputcommand.js
@@ -8,6 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
+
 import ChangeBuffer from './utils/changebuffer';
 
 /**
@@ -82,7 +83,7 @@ export default class InputCommand extends Command {
 			this._buffer.lock();
 
 			if ( !isCollapsedRange ) {
-				writer.remove( range );
+				model.deleteContent( model.createSelection( range ) );
 			}
 
 			if ( text ) {

--- a/tests/deletecommand.js
+++ b/tests/deletecommand.js
@@ -3,8 +3,11 @@
  * For licensing, see LICENSE.md.
  */
 
+import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 import DeleteCommand from '../src/deletecommand';
+import Delete from '../src/delete';
+import ChangeBuffer from '../src/utils/changebuffer';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
@@ -36,6 +39,29 @@ describe( 'DeleteCommand', () => {
 		const command = new DeleteCommand( editor, 'forward' );
 
 		expect( command ).to.have.property( 'direction', 'forward' );
+	} );
+
+	describe( 'buffer', () => {
+		it( 'has buffer getter', () => {
+			expect( editor.commands.get( 'delete' ).buffer ).to.be.an.instanceof( ChangeBuffer );
+		} );
+
+		it( 'has a buffer limit configured to default value of 20', () => {
+			expect( editor.commands.get( 'delete' ).buffer ).to.have.property( 'limit', 20 );
+		} );
+
+		it( 'has a buffer configured to config.typing.undoStep', () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ Delete ],
+					typing: {
+						undoStep: 5
+					}
+				} )
+				.then( editor => {
+					expect( editor.commands.get( 'delete' ).buffer ).to.have.property( 'limit', 5 );
+				} );
+		} );
 	} );
 
 	describe( 'execute()', () => {

--- a/tests/inputcommand.js
+++ b/tests/inputcommand.js
@@ -147,7 +147,7 @@ describe( 'InputCommand', () => {
 				range: doc.selection.getFirstRange()
 			} );
 
-			expect( getData( model, { selection: true } ) ).to.be.equal( '<h1>Funny c[</h1><p>]ar</p>' );
+			expect( getData( model, { selection: true } ) ).to.be.equal( '<h1>Funny c[]ar</h1>' );
 			expect( buffer.size ).to.be.equal( 6 );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Exposed `DeleteCommand#buffer`. `InputCommand` uses `Model#deleteContent` instead of `model.Writer#remove`.

---

### Additional information

These are changes that are needed for track changes plugin.
