### PR TITLE
Mutation handling crashed in particular scenarios (when old text was same as new text)

### DIFF
--- a/src/utils/injecttypingmutationshandling.js
+++ b/src/utils/injecttypingmutationshandling.js
@@ -200,6 +200,11 @@ class MutationHandler {
 		// To have correct `diffResult`, we also compare view node text data with &nbsp; replaced by space.
 		const oldText = mutation.oldText.replace( /\u00A0/g, ' ' );
 
+		// Do nothing if mutations created same text.
+		if ( oldText === newText ) {
+			return;
+		}
+
 		const diffResult = diff( oldText, newText );
 
 		const { firstChangeAt, insertions, deletions } = calculateChanges( diffResult );

--- a/tests/input.js
+++ b/tests/input.js
@@ -647,6 +647,32 @@ describe( 'Input feature', () => {
 
 			expect( getViewData( view ) ).to.equal( '<p>foo<placeholder></placeholder>bar<placeholder></placeholder>baz!{}</p>' );
 		} );
+
+		// https://github.com/ckeditor/ckeditor5-typing/issues/181
+		it( 'should not crash if the mutation old text is same as new text', () => {
+			// It shouldn't matter what data is here, I am putting it like it is in the test scenario, but it is really about
+			// what mutations are generated.
+			editor.setData( '<p>Foo<strong> </strong>&nbsp;Bar</p>' );
+
+			const p = viewRoot.getChild( 0 );
+
+			viewDocument.fire( 'mutations', [
+				{
+					type: 'text',
+					oldText: ' ',
+					newText: ' ',
+					node: p.getChild( 1 )
+				},
+				{
+					type: 'text',
+					oldText: 'Foo',
+					newText: 'Foox',
+					node: p.getChild( 0 )
+				}
+			] );
+
+			expect( getViewData( view ) ).to.equal( '<p>Foox{}<strong> </strong> Bar</p>' );
+		} );
 	} );
 
 	describe( 'keystroke handling', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Mutation handling crashed in particular scenarios (when old text was same as new text). Closes #181.