### PR TITLE
Delete event should be stopped after delete command is executed to prevent double handling

### DIFF
--- a/src/delete.js
+++ b/src/delete.js
@@ -38,7 +38,10 @@ export default class Delete extends Plugin {
 
 		this.listenTo( viewDocument, 'delete', ( evt, data ) => {
 			editor.execute( data.direction == 'forward' ? 'forwardDelete' : 'delete', { unit: data.unit, sequence: data.sequence } );
+
+			evt.stop();
 			data.preventDefault();
+
 			view.scrollToTheSelection();
 		} );
 

--- a/tests/delete.js
+++ b/tests/delete.js
@@ -54,6 +54,27 @@ describe( 'Delete feature', () => {
 		expect( spy.calledWithMatch( 'delete', { unit: 'character', sequence: 5 } ) ).to.be.true;
 	} );
 
+	it( 'stops delete event after executing a command', () => {
+		const spy = editor.execute = sinon.spy();
+		const eventSpy = sinon.spy();
+
+		const viewDocument = editor.editing.view.document;
+		const domEvt = getDomEvent();
+
+		viewDocument.on( 'delete', eventSpy );
+
+		viewDocument.fire( 'delete', new DomEventData( viewDocument, domEvt, {
+			direction: 'forward',
+			unit: 'character',
+			sequence: 1
+		} ) );
+
+		expect( spy.calledOnce ).to.be.true;
+		expect( spy.calledWithMatch( 'forwardDelete', { unit: 'character', sequence: 1 } ) ).to.be.true;
+
+		expect( eventSpy.called ).to.be.false;
+	} );
+
 	it( 'scrolls the editing document to the selection after executing the command', () => {
 		const scrollSpy = sinon.stub( editor.editing.view, 'scrollToTheSelection' );
 		const executeSpy = editor.execute = sinon.spy();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Delete event should be stopped after delete command is executed to prevent double handling. Closes #184.