### PR TITLE
delete event didn't stop keydown event if it was set with highest priority

### DIFF
--- a/src/deleteobserver.js
+++ b/src/deleteobserver.js
@@ -49,9 +49,10 @@ export default class DeleteObserver extends Observer {
 
 			// Save the event object to check later if it was stopped or not.
 			let event;
-			document.once( 'delete', evt => ( event = evt ), { priority: 'highest' } );
+			document.once( 'delete', evt => ( event = evt ), { priority: Number.POSITIVE_INFINITY } );
 
-			document.fire( 'delete', new DomEventData( document, data.domEvent, deleteData ) );
+			const domEvtData = new DomEventData( document, data.domEvent, deleteData );
+			document.fire( 'delete', domEvtData );
 
 			// Stop `keydown` event if `delete` event was stopped.
 			// https://github.com/ckeditor/ckeditor5/issues/753

--- a/tests/deleteobserver.js
+++ b/tests/deleteobserver.js
@@ -214,6 +214,19 @@ describe( 'DeleteObserver', () => {
 			sinon.assert.notCalled( keydownSpy );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-typing/issues/186
+		it( 'should stop keydown event when delete event is stopped (delete event with highest priority)', () => {
+			const keydownSpy = sinon.spy();
+			viewDocument.on( 'keydown', keydownSpy );
+			viewDocument.on( 'delete', evt => evt.stop(), { priority: 'highest' } );
+
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'delete' )
+			} ) );
+
+			sinon.assert.notCalled( keydownSpy );
+		} );
+
 		it( 'should not stop keydown event when delete event is not stopped', () => {
 			const keydownSpy = sinon.spy();
 			viewDocument.on( 'keydown', keydownSpy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: `delete` event didn't stop `keydown` event if it was set with `highest` priority. Closes #186.