### PR TITLE
Use model.insertContent instead of model.Writer#insertText

### DIFF
--- a/src/inputcommand.js
+++ b/src/inputcommand.js
@@ -82,12 +82,10 @@ export default class InputCommand extends Command {
 
 			this._buffer.lock();
 
-			if ( !isCollapsedRange ) {
-				model.deleteContent( model.createSelection( range ) );
-			}
+			model.deleteContent( model.createSelection( range ) );
 
 			if ( text ) {
-				writer.insertText( text, doc.selection.getAttributes(), range.start );
+				model.insertContent( writer.createText( text, doc.selection.getAttributes() ), range.start );
 			}
 
 			if ( resultRange ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Use `model.insertContent` instead of `model.Writer#insertText`. Closes #191.