### PR TITLE
T/208: TextTransformation should only consider typing changes

### DIFF
--- a/src/input.js
+++ b/src/input.js
@@ -41,6 +41,15 @@ export default class Input extends Plugin {
 		injectTypingMutationsHandling( editor );
 	}
 
+	/**
+	 * Checks batch if is a result of user input - ie typing.
+	 *
+	 * **Note:** This method checks if the batch was created using {@link module:typing/inputcommand~InputCommand 'input'}
+	 * command as typing changes coming from user input are inserted to the document using that command.
+	 *
+	 * @param {module:engine/model/batch~Batch} batch A batch to check.
+	 * @returns {Boolean}
+	 */
 	isInput( batch ) {
 		const inputCommand = this.editor.commands.get( 'input' );
 

--- a/src/input.js
+++ b/src/input.js
@@ -47,7 +47,7 @@ export default class Input extends Plugin {
 	 *		const input = editor.plugins.get( 'Input' );
 	 *
 	 *		editor.model.document.on( 'change:data', ( evt, batch ) => {
-	 *			if ( input.isTyping( batch) ) {
+	 *			if ( input.isTyping( batch ) ) {
 	 *				console.log( 'The user typed something...' );
 	 *			}
 	 *		} );

--- a/src/input.js
+++ b/src/input.js
@@ -42,7 +42,7 @@ export default class Input extends Plugin {
 	}
 
 	/**
-	 * Checks batch if is a result of user input - ie typing.
+	 * Checks batch if it is a result of user input - e.g. typing.
 	 *
 	 * **Note:** This method checks if the batch was created using {@link module:typing/inputcommand~InputCommand 'input'}
 	 * command as typing changes coming from user input are inserted to the document using that command.

--- a/src/input.js
+++ b/src/input.js
@@ -40,4 +40,10 @@ export default class Input extends Plugin {
 		injectUnsafeKeystrokesHandling( editor );
 		injectTypingMutationsHandling( editor );
 	}
+
+	isInput( batch ) {
+		const inputCommand = this.editor.commands.get( 'input' );
+
+		return inputCommand._batches.has( batch );
+	}
 }

--- a/src/input.js
+++ b/src/input.js
@@ -44,6 +44,14 @@ export default class Input extends Plugin {
 	/**
 	 * Checks batch if it is a result of user input - e.g. typing.
 	 *
+	 *		const input = editor.plugins.get( 'Input' );
+	 *
+	 *		editor.model.document.on( 'change:data', ( evt, batch ) => {
+	 *			if ( input.isTyping( batch) ) {
+	 *				console.log( 'The user typed something...' );
+	 *			}
+	 *		} );
+	 *
 	 * **Note:** This method checks if the batch was created using {@link module:typing/inputcommand~InputCommand 'input'}
 	 * command as typing changes coming from user input are inserted to the document using that command.
 	 *

--- a/src/inputcommand.js
+++ b/src/inputcommand.js
@@ -41,7 +41,7 @@ export default class InputCommand extends Command {
 		 * {@link module:typing/input~Input#isInput} method.
 		 *
 		 * @type {WeakSet<module:engine/model/batch~Batch>}
-		 * @private
+		 * @protected
 		 */
 		this._batches = new WeakSet();
 	}

--- a/src/inputcommand.js
+++ b/src/inputcommand.js
@@ -36,6 +36,13 @@ export default class InputCommand extends Command {
 		 */
 		this._buffer = new ChangeBuffer( editor.model, undoStepSize );
 
+		/**
+		 * Stores batches created by the input command. The batches are used to differentiate input batches from other batches using
+		 * {@link module:typing/input~Input#isInput} method.
+		 *
+		 * @type {WeakSet<module:engine/model/batch~Batch>}
+		 * @private
+		 */
 		this._batches = new WeakSet();
 	}
 
@@ -101,6 +108,7 @@ export default class InputCommand extends Command {
 
 			this._buffer.input( textInsertions );
 
+			// Store the batch as an 'input' batch for the Input.isInput( batch ) check.
 			this._batches.add( this._buffer.batch );
 		} );
 	}

--- a/src/inputcommand.js
+++ b/src/inputcommand.js
@@ -35,6 +35,8 @@ export default class InputCommand extends Command {
 		 * @member {module:typing/utils/changebuffer~ChangeBuffer} #_buffer
 		 */
 		this._buffer = new ChangeBuffer( editor.model, undoStepSize );
+
+		this._batches = new WeakSet();
 	}
 
 	/**
@@ -98,6 +100,8 @@ export default class InputCommand extends Command {
 			this._buffer.unlock();
 
 			this._buffer.input( textInsertions );
+
+			this._batches.add( this._buffer.batch );
 		} );
 	}
 }

--- a/src/texttransformation.js
+++ b/src/texttransformation.js
@@ -111,6 +111,10 @@ export default class TextTransformation extends Plugin {
 			const watcher = new TextWatcher( editor.model, text => from.test( text ) );
 
 			watcher.on( 'matched:data', ( evt, data ) => {
+				if ( !data.isTyping ) {
+					return;
+				}
+
 				const matches = from.exec( data.text );
 				const replaces = to( matches.slice( 1 ) );
 

--- a/src/texttransformation.js
+++ b/src/texttransformation.js
@@ -101,6 +101,7 @@ export default class TextTransformation extends Plugin {
 	init() {
 		const editor = this.editor;
 		const model = editor.model;
+		const input = editor.plugins.get( 'Input' );
 
 		const configuredTransformations = getConfiguredTransformations( editor.config.get( 'typing.transformations' ) );
 
@@ -111,7 +112,7 @@ export default class TextTransformation extends Plugin {
 			const watcher = new TextWatcher( editor.model, text => from.test( text ) );
 
 			watcher.on( 'matched:data', ( evt, data ) => {
-				if ( !data.isTyping ) {
+				if ( !input.isInput( data.batch ) ) {
 					return;
 				}
 

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -106,14 +106,16 @@ export default class TextWatcher {
 			 * Fired whenever the text watcher found a match for data changes.
 			 *
 			 * @event matched:data
-			 * @param {String} text The full text before selection.
-			 * @param {Boolean} isTyping Set to true for user typing changes.
+			 * @param {Object} data Event data.
+			 * @param {String} data.text The full text before selection.
+			 * @param {Boolean} data.isTyping Set to true for user typing changes.
 			 */
 			/**
 			 * Fired whenever the text watcher found a match for selection changes.
 			 *
 			 * @event matched:selection
-			 * @param {String} text The full text before selection.
+			 * @param {Object} data Event data.
+			 * @param {String} data.text The full text before selection.
 			 */
 			this.fire( `matched:${ suffix }`, eventData );
 		}

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -106,7 +106,7 @@ export default class TextWatcher {
 			 * @event matched:data
 			 * @param {Object} data Event data.
 			 * @param {String} data.text The full text before selection.
-			 * @param {Boolean} data.isTyping Set to true for user typing changes.
+			 * @param {module:engine/model/batch~Batch} data.batch A batch associated with a change.
 			 */
 			/**
 			 * Fired whenever the text watcher found a match for selection changes.

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -66,9 +66,7 @@ export default class TextWatcher {
 				return;
 			}
 
-			const isTyping = checkTyping( model );
-
-			this._evaluateTextBeforeSelection( 'data', { isTyping } );
+			this._evaluateTextBeforeSelection( 'data', { batch } );
 		} );
 	}
 
@@ -151,23 +149,6 @@ function _getText( range ) {
 
 		return rangeText + node.data;
 	}, '' );
-}
-
-// Returns true if the change was done by typing.
-//
-// @param {module:engine/model/model~Model} model
-function checkTyping( model ) {
-	const changes = Array.from( model.document.differ.getChanges() );
-
-	// Typing is represented by only a single change...
-	if ( changes.length != 1 ) {
-		return false;
-	}
-
-	const entry = changes[ 0 ];
-
-	// ...and is an insert of a text.
-	return entry.type === 'insert' && entry.name == '$text' && entry.length == 1;
 }
 
 mix( TextWatcher, EmitterMixin );

--- a/tests/input.js
+++ b/tests/input.js
@@ -70,6 +70,29 @@ describe( 'Input feature', () => {
 		return editor.destroy();
 	} );
 
+	describe( 'isInput()', () => {
+		let input;
+
+		beforeEach( () => {
+			input = editor.plugins.get( 'Input' );
+		} );
+
+		it( 'returns true for batch created using "input" command', done => {
+			model.document.once( 'change:data', ( evt, batch ) => {
+				expect( input.isInput( batch ) ).to.be.true;
+				done();
+			} );
+
+			editor.execute( 'input', { text: 'foo' } );
+		} );
+
+		it( 'returns false for batch not created using "input" command', () => {
+			const batch = model.createBatch();
+
+			expect( input.isInput( batch ) ).to.be.false;
+		} );
+	} );
+
 	describe( 'mutations handling', () => {
 		it( 'should handle text mutation', () => {
 			viewDocument.fire( 'mutations', [

--- a/tests/texttransformation-integration.js
+++ b/tests/texttransformation-integration.js
@@ -12,6 +12,7 @@ import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictest
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 import TextTransformation from '../src/texttransformation';
+import Typing from '../src/typing';
 
 describe( 'Text transformation feature - integration', () => {
 	let editorElement, editor, model, doc;
@@ -32,7 +33,7 @@ describe( 'Text transformation feature - integration', () => {
 	describe( 'with undo', () => {
 		beforeEach( () => {
 			return ClassicTestEditor
-				.create( editorElement, { plugins: [ Paragraph, TextTransformation, UndoEditing ] } )
+				.create( editorElement, { plugins: [ Typing, Paragraph, TextTransformation, UndoEditing ] } )
 				.then( newEditor => {
 					editor = newEditor;
 					model = editor.model;

--- a/tests/texttransformation-integration.js
+++ b/tests/texttransformation-integration.js
@@ -47,12 +47,10 @@ describe( 'Text transformation feature - integration', () => {
 			model.enqueueChange( model.createBatch(), writer => {
 				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
 				writer.insertText( '(c', doc.selection.focus );
+				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
 			} );
 
-			model.enqueueChange( model.createBatch(), writer => {
-				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
-				writer.insertText( ')', doc.selection.focus );
-			} );
+			editor.execute( 'input', { text: ')' } );
 
 			expect( editor.getData(), 'inserted text' ).to.equal( '<p>foo©</p>' );
 
@@ -71,12 +69,11 @@ describe( 'Text transformation feature - integration', () => {
 			model.enqueueChange( model.createBatch(), writer => {
 				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
 				writer.insertText( 'foo bar baz(c', doc.selection.focus );
+				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
 			} );
 
-			model.enqueueChange( model.createBatch(), writer => {
-				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
-				writer.insertText( ')', doc.selection.focus );
-			} );
+			editor.execute( 'input', { text: ')' } );
+
 			expect( editor.getData() ).to.equal( '<p>foo bar baz©</p>' );
 
 			editor.execute( 'undo' );

--- a/tests/texttransformation-integration.js
+++ b/tests/texttransformation-integration.js
@@ -47,7 +47,6 @@ describe( 'Text transformation feature - integration', () => {
 			model.enqueueChange( model.createBatch(), writer => {
 				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
 				writer.insertText( '(c', doc.selection.focus );
-				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
 			} );
 
 			editor.execute( 'input', { text: ')' } );
@@ -69,7 +68,6 @@ describe( 'Text transformation feature - integration', () => {
 			model.enqueueChange( model.createBatch(), writer => {
 				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
 				writer.insertText( 'foo bar baz(c', doc.selection.focus );
-				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
 			} );
 
 			editor.execute( 'input', { text: ')' } );

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -6,6 +6,7 @@
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
+import Typing from '../src/typing';
 import TextTransformation from '../src/texttransformation';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
@@ -115,15 +116,17 @@ describe( 'Text transformation feature', () => {
 			simulateTyping( '"' );
 
 			expect( getData( model, { withoutSelection: true } ) )
-				.to.equal( '<paragraph>Foo “<$text bold="true">Bar</$text>”</paragraph>' );
+				.to.equal( '<paragraph>Foo “<$text bold="true">Bar”</$text></paragraph>' );
 		} );
 
 		it( 'should keep styles of the replaced text #1', () => {
 			setData( model, '<paragraph>Foo <$text bold="true">"</$text>Bar[]</paragraph>' );
 
 			model.change( writer => {
-				writer.insertText( '"', { bold: true }, doc.selection.focus );
+				writer.setSelectionAttribute( { bold: true } );
 			} );
+
+			simulateTyping( '"' );
 
 			expect( getData( model, { withoutSelection: true } ) )
 				.to.equal( '<paragraph>Foo <$text bold="true">“</$text>Bar<$text bold="true">”</$text></paragraph>' );
@@ -336,7 +339,7 @@ describe( 'Text transformation feature', () => {
 	function createEditorInstance( additionalConfig = {} ) {
 		return ClassicTestEditor
 			.create( editorElement, Object.assign( {
-				plugins: [ Paragraph, Bold, TextTransformation ]
+				plugins: [ Typing, Paragraph, Bold, TextTransformation ]
 			}, additionalConfig ) )
 			.then( newEditor => {
 				editor = newEditor;
@@ -350,9 +353,7 @@ describe( 'Text transformation feature', () => {
 		const letters = transformFrom.split( '' );
 
 		for ( const letter of letters ) {
-			model.enqueueChange( model.createBatch(), writer => {
-				writer.insertText( letter, doc.selection.focus );
-			} );
+			editor.execute( 'input', { text: letter } );
 		}
 	}
 } );

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -52,6 +52,30 @@ describe( 'Text transformation feature', () => {
 			expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>foo bar(tm) baz</paragraph>' );
 		} );
 
+		it( 'should not work for deletion changes', () => {
+			setData( model, '<paragraph>foo bar(tm) []</paragraph>' );
+
+			// Simulate delete command.
+			model.change( writer => {
+				const selection = writer.createSelection( doc.selection );
+				model.modifySelection( selection, { direction: 'backward', unit: 'character' } );
+				model.deleteContent( selection, { doNotResetEntireContent: true } );
+			} );
+
+			expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>foo bar(tm)</paragraph>' );
+		} );
+
+		it( 'should not work for merging changes', () => {
+			setData( model, '<paragraph>foo bar(tm)</paragraph><paragraph>[] baz</paragraph>' );
+
+			// Simulate delete command.
+			model.change( writer => {
+				writer.merge( writer.createPositionAfter( doc.getRoot().getChild( 0 ) ) );
+			} );
+
+			expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>foo bar(tm) baz</paragraph>' );
+		} );
+
 		describe( 'symbols', () => {
 			testTransformation( '(c)', '©' );
 			testTransformation( '(r)', '®' );
@@ -88,9 +112,7 @@ describe( 'Text transformation feature', () => {
 		it( 'should replace only the parts of content which changed', () => {
 			setData( model, '<paragraph>Foo "<$text bold="true">Bar</$text>[]</paragraph>' );
 
-			model.change( writer => {
-				writer.insertText( '"', doc.selection.focus );
-			} );
+			simulateTyping( '"' );
 
 			expect( getData( model, { withoutSelection: true } ) )
 				.to.equal( '<paragraph>Foo “<$text bold="true">Bar</$text>”</paragraph>' );
@@ -110,9 +132,7 @@ describe( 'Text transformation feature', () => {
 		it( 'should keep styles of the replaced text #2', () => {
 			setData( model, '<paragraph>F<$text bold="true">oo "B</$text>ar[]</paragraph>' );
 
-			model.change( writer => {
-				writer.insertText( '"', doc.selection.focus );
-			} );
+			simulateTyping( '"' );
 
 			expect( getData( model, { withoutSelection: true } ) )
 				.to.equal( '<paragraph>F<$text bold="true">oo “B</$text>ar”</paragraph>' );
@@ -122,13 +142,7 @@ describe( 'Text transformation feature', () => {
 			it( `should transform "${ transformFrom }" to "${ transformTo }"`, () => {
 				setData( model, '<paragraph>A foo[]</paragraph>' );
 
-				const letters = transformFrom.split( '' );
-
-				for ( const letter of letters ) {
-					model.enqueueChange( model.createBatch(), writer => {
-						writer.insertText( letter, doc.selection.focus );
-					} );
-				}
+				simulateTyping( transformFrom );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( `<paragraph>A foo${ transformTo }</paragraph>` );
 			} );
@@ -164,9 +178,7 @@ describe( 'Text transformation feature', () => {
 			} ).then( () => {
 				setData( model, '<paragraph>[]</paragraph>' );
 
-				model.enqueueChange( model.createBatch(), writer => {
-					writer.insertText( 'CKE', doc.selection.focus );
-				} );
+				simulateTyping( 'CKE' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor</paragraph>' );
 			} );
@@ -184,9 +196,7 @@ describe( 'Text transformation feature', () => {
 			} ).then( () => {
 				setData( model, '<paragraph>[]</paragraph>' );
 
-				model.enqueueChange( model.createBatch(), writer => {
-					writer.insertText( 'user@example.com', doc.selection.focus );
-				} );
+				simulateTyping( 'user@example.com' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>user.at.example.com</paragraph>' );
 			} );
@@ -204,9 +214,7 @@ describe( 'Text transformation feature', () => {
 			} ).then( () => {
 				setData( model, '<paragraph>Foo. []</paragraph>' );
 
-				model.enqueueChange( model.createBatch(), writer => {
-					writer.insertText( 'b', doc.selection.focus );
-				} );
+				simulateTyping( 'b' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>Foo. B</paragraph>' );
 			} );
@@ -224,15 +232,11 @@ describe( 'Text transformation feature', () => {
 			} ).then( () => {
 				setData( model, '<paragraph>[]</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( 'CKE', doc.selection.focus );
-				} );
+				simulateTyping( 'CKE' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( '(tm)', doc.selection.focus );
-				} );
+				simulateTyping( '(tm)' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor™</paragraph>' );
 			} );
@@ -250,15 +254,11 @@ describe( 'Text transformation feature', () => {
 			} ).then( () => {
 				setData( model, '<paragraph>[]</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( 'CKE', doc.selection.focus );
-				} );
+				simulateTyping( 'CKE' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( '(tm)', doc.selection.focus );
-				} );
+				simulateTyping( '(tm)' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor(tm)</paragraph>' );
 			} );
@@ -275,15 +275,11 @@ describe( 'Text transformation feature', () => {
 			} ).then( () => {
 				setData( model, '<paragraph>[]</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( '(tm)', doc.selection.focus );
-				} );
+				simulateTyping( '(tm)' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>(tm)</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( '(r)', doc.selection.focus );
-				} );
+				simulateTyping( '(r)' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>(tm)®</paragraph>' );
 			} );
@@ -300,15 +296,11 @@ describe( 'Text transformation feature', () => {
 			} ).then( () => {
 				setData( model, '<paragraph>[]</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( '(tm)', doc.selection.focus );
-				} );
+				simulateTyping( '(tm)' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>(tm)</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( '...', doc.selection.focus );
-				} );
+				simulateTyping( '...' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>(tm)…</paragraph>' );
 			} );
@@ -334,9 +326,7 @@ describe( 'Text transformation feature', () => {
 			} ).then( () => {
 				setData( model, '<paragraph>[]</paragraph>' );
 
-				model.change( writer => {
-					writer.insertText( '(tm)', doc.selection.focus );
-				} );
+				simulateTyping( '(tm)' );
 
 				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>™</paragraph>' );
 			} );
@@ -354,5 +344,15 @@ describe( 'Text transformation feature', () => {
 				model = editor.model;
 				doc = model.document;
 			} );
+	}
+
+	function simulateTyping( transformFrom ) {
+		const letters = transformFrom.split( '' );
+
+		for ( const letter of letters ) {
+			model.enqueueChange( model.createBatch(), writer => {
+				writer.insertText( letter, doc.selection.focus );
+			} );
+		}
 	}
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Introduce `Input.isInput()` method. Closes #214. Also introduces a fix for the TextTransformation feature - it willl only consider typing changes. Closes #208.


---

### Additional information

* This PR fixes two bugs with deletion: transformation on delete and transformation on merging (ie paragraphs).
* This PR also introduces `Input.isInput()` check. #214.

