### PR TITLE
External modifications of the editing root should not crash the editor

### DIFF
--- a/src/utils/injecttypingmutationshandling.js
+++ b/src/utils/injecttypingmutationshandling.js
@@ -119,7 +119,9 @@ class MutationHandler {
 		// This situation happens for example for lists. If `<ul>` is a common ancestor, `currentModel` is `undefined`
 		// because `<ul>` is not mapped (`<li>`s are).
 		// See https://github.com/ckeditor/ckeditor5/issues/718.
-		if ( !currentModel ) {
+		// Also, if a current DOM was cleared (happened with VUE integration - it is also safe to return early here.
+		// See https://github.com/ckeditor/ckeditor5/issues/2016.
+		if ( !currentModel || !modelFromCurrentDom ) {
 			return;
 		}
 

--- a/tests/input.js
+++ b/tests/input.js
@@ -697,6 +697,32 @@ describe( 'Input feature', () => {
 
 			expect( getViewData( view ) ).to.equal( '<p>Foox{}<strong> </strong> Bar</p>' );
 		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/2016
+		it( 'should not crash on external modifications to the editing DOM root', done => {
+			editor.setData( '<p>Foo</p>' );
+
+			model.document.on( 'change:data', () => {
+				const domRoot = editor.editing.view.getDomRoot( 'main' );
+				domRoot.removeChild( domRoot.children[ 0 ] );
+
+				const p = viewRoot.getChild( 0 );
+
+				viewDocument.fire( 'mutations', [
+					{
+						type: 'children',
+						oldChildren: [ p ],
+						newChildren: [],
+						node: viewRoot
+					}
+				] );
+
+				done();
+			} );
+
+			const paragraph = model.document.getRoot().getChild( 0 );
+			model.deleteContent( model.createSelection( paragraph, 'in' ) );
+		} );
 	} );
 
 	describe( 'keystroke handling', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

External modifications of the editing root should not crash the editor. Closes ckeditor/ckeditor5#2016.

---

### Additional information

* I've found out that if we initialize the editing area directly as a Vue component root then Vue updates the children of the editing area on removing all nodes.
* This touches only `EditorInline` and `BallonEditor` as those are used directly as a component root. The `ClassicEditor` is not touched by this as its editing area is wrapped in another `<div>` which is then used as component root.
* More links here: https://github.com/ckeditor/ckeditor5/issues/2016#issuecomment-531158714.
* This behavior in Vue is didctated by some old Chrome bug (v. 55): https://github.com/vuejs/vue/issues/6601
