### PR TITLE
I/5862: Disable text transformations inside code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@ckeditor/ckeditor5-list": "^16.0.0",
     "@ckeditor/ckeditor5-paragraph": "^16.0.0",
     "@ckeditor/ckeditor5-undo": "^16.0.0",
+    "@ckeditor/ckeditor5-code-block": "^16.0.0",
     "eslint": "^5.5.0",
     "eslint-config-ckeditor5": "^2.0.0",
     "husky": "^1.3.1",

--- a/src/texttransformation.js
+++ b/src/texttransformation.js
@@ -107,32 +107,6 @@ export default class TextTransformation extends Plugin {
 		const modelSelection = modelDocument.selection;
 
 		/**
-		 * Flag indicating whether a plugin is enabled or disabled.
-		 * A disabled plugin will not transform text.
-		 *
-		 * Plugin can be simply disabled like that:
-		 *
-		 *		// Disable the plugin so that no toolbars are visible.
-		 *		editor.plugins.get( 'TextTransformation' ).isEnabled = false;
-		 *
-		 * You can also use {@link module:utils/forcedisabledmixin~ForceDisabledMixin#forceDisabled} method.
-		 *
-		 *
-		 * @observable
-		 * @readonly
-		 * @member {Boolean} #isEnabled
-		 */
-		this.set( 'isEnabled', true );
-
-		/**
-		 * Holds identifiers for {@link module:utils/forcedisabledmixin~ForceDisabledMixin#forceDisabled} mechanism.
-		 *
-		 * @type {Set.<String>}
-		 * @private
-		 */
-		this._disableStack = new Set();
-
-		/**
 		 * Holds a set of active {@link module:typing/textwatcher~TextWatcher}
 		 *
 		 * @type {Set.<TextWatcher>}

--- a/src/texttransformation.js
+++ b/src/texttransformation.js
@@ -10,8 +10,6 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import TextWatcher from './textwatcher';
 import { escapeRegExp } from 'lodash-es';
-import ForceDisabledMixin from '@ckeditor/ckeditor5-utils/src/forcedisabledmixin';
-import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
 // All named transformations.
 const TRANSFORMATIONS = {
@@ -197,8 +195,6 @@ export default class TextTransformation extends Plugin {
 		this._watchersStack.clear();
 	}
 }
-
-mix( TextTransformation, ForceDisabledMixin );
 
 // Normalizes the configuration `from` parameter value.
 // The normalized value for the `from` parameter is a RegExp instance. If the passed `from` is already a RegExp instance,

--- a/src/texttransformation.js
+++ b/src/texttransformation.js
@@ -101,8 +101,7 @@ export default class TextTransformation extends Plugin {
 	 */
 	init() {
 		const model = this.editor.model;
-		const modelDocument = model.document;
-		const modelSelection = modelDocument.selection;
+		const modelSelection = model.document.selection;
 
 		/**
 		 * Holds a set of active {@link module:typing/textwatcher~TextWatcher}
@@ -116,12 +115,12 @@ export default class TextTransformation extends Plugin {
 			this.isEnabled ? this._enableTransformationWatchers() : this._disableTransformationWatchers();
 		} );
 
-		this._enableTransformationWatchers();
-
-		this.listenTo( modelDocument, 'change:data', () => {
-			// Disable plugin when typing in code block.
+		modelSelection.on( 'change:range', () => {
+			// Disable plugin when selection is inside a code block.
 			this.isEnabled = !modelSelection.anchor.parent.is( 'codeBlock' );
 		} );
+
+		this._enableTransformationWatchers();
 	}
 
 	/**

--- a/src/texttransformation.js
+++ b/src/texttransformation.js
@@ -103,18 +103,6 @@ export default class TextTransformation extends Plugin {
 		const model = this.editor.model;
 		const modelSelection = model.document.selection;
 
-		/**
-		 * Holds a set of active {@link module:typing/textwatcher~TextWatcher}
-		 *
-		 * @type {Set.<TextWatcher>}
-		 * @private
-		 */
-		this._watchersStack = new Set();
-
-		this.on( 'change:isEnabled', () => {
-			this.isEnabled ? this._enableTransformationWatchers() : this._disableTransformationWatchers();
-		} );
-
 		modelSelection.on( 'change:range', () => {
 			// Disable plugin when selection is inside a code block.
 			this.isEnabled = !modelSelection.anchor.parent.is( 'codeBlock' );
@@ -175,23 +163,9 @@ export default class TextTransformation extends Plugin {
 				} );
 			};
 
-			this._watchersStack.add( watcher );
-
 			watcher.on( 'matched:data', watcherCallback );
+			watcher.bind( 'isEnabled' ).to( this );
 		}
-	}
-
-	/**
-	 * Disable each running TextWatcher and clear the set of enabled watchers after all.
-	 *
-	 * @private
-	 */
-	_disableTransformationWatchers() {
-		this._watchersStack.forEach( watcher => {
-			watcher.stopListening();
-		} );
-
-		this._watchersStack.clear();
 	}
 }
 

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -19,14 +19,14 @@ import getLastTextLine from './utils/getlasttextline';
  * {@link module:typing/textwatcher~TextWatcher#event:unmatched `unmatched`} events on typing or selection changes.
  *
  * @private
+ * @mixes module:utils/observablemixin~ObservableMixin
  */
 export default class TextWatcher {
 	/**
 	 * Creates a text watcher instance.
+	 *
 	 * @param {module:engine/model/model~Model} model
 	 * @param {Function} testCallback The function used to match the text.
-	 *
-	 * @mixes module:utils/observablemixin~ObservableMixin
 	 */
 	constructor( model, testCallback ) {
 		this.model = model;
@@ -37,15 +37,14 @@ export default class TextWatcher {
 		 * Flag indicating whether the TextWatcher is enabled or disabled.
 		 * A disabled TextWatcher will not evaluate text.
 		 *
-		 * TextWatcher can be simply disabled like that:
+		 * To disable TextWatcher:
 		 *
-		 *		// Disable the TextWatcher so that it doesn't evaluate text.
-		 *		const watcher = new TextWatcher( editor.model, text => from.test( text ) );
+		 *		const watcher = new TextWatcher( editor.model, testCallback );
+		 *
+		 *		// After this a testCallback will not be called.
 		 *		watcher.isEnabled = false;
 		 *
-		 *
 		 * @observable
-		 * @readonly
 		 * @member {Boolean} #isEnabled
 		 */
 		this.set( 'isEnabled', true );

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -43,7 +43,7 @@ export default class TextWatcher {
 		const model = this.model;
 		const document = model.document;
 
-		document.selection.on( 'change:range', ( evt, { directChange } ) => {
+		this.listenTo( document.selection, 'change:range', ( evt, { directChange } ) => {
 			// Indirect changes (i.e. when the user types or external changes are applied) are handled in the document's change event.
 			if ( !directChange ) {
 				return;
@@ -62,7 +62,7 @@ export default class TextWatcher {
 			this._evaluateTextBeforeSelection( 'selection' );
 		} );
 
-		document.on( 'change:data', ( evt, batch ) => {
+		this.listenTo( document, 'change:data', ( evt, batch ) => {
 			if ( batch.type == 'transparent' ) {
 				return;
 			}
@@ -128,4 +128,3 @@ export default class TextWatcher {
 }
 
 mix( TextWatcher, EmitterMixin );
-

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -8,7 +8,6 @@
  */
 
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
-import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import getLastTextLine from './utils/getlasttextline';
 
@@ -26,12 +25,29 @@ export default class TextWatcher {
 	 * Creates a text watcher instance.
 	 * @param {module:engine/model/model~Model} model
 	 * @param {Function} testCallback The function used to match the text.
+	 *
+	 * @mixes module:utils/observablemixin~ObservableMixin
 	 */
 	constructor( model, testCallback ) {
 		this.model = model;
 		this.testCallback = testCallback;
 		this.hasMatch = false;
 
+		/**
+		 * Flag indicating whether the TextWatcher is enabled or disabled.
+		 * A disabled TextWatcher will not evaluate text.
+		 *
+		 * TextWatcher can be simply disabled like that:
+		 *
+		 *		// Disable the TextWatcher so that it doesn't evaluate text.
+		 *		const watcher = new TextWatcher( editor.model, text => from.test( text ) );
+		 *		watcher.isEnabled = false;
+		 *
+		 *
+		 * @observable
+		 * @readonly
+		 * @member {Boolean} #isEnabled
+		 */
 		this.set( 'isEnabled', true );
 
 		// Toggle text watching on isEnabled state change.
@@ -140,4 +156,4 @@ export default class TextWatcher {
 	}
 }
 
-mix( TextWatcher, EmitterMixin, ObservableMixin );
+mix( TextWatcher, ObservableMixin );

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -9,6 +9,7 @@
 
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import getLastTextLine from './utils/getlasttextline';
 
 /**
@@ -31,6 +32,8 @@ export default class TextWatcher {
 		this.testCallback = testCallback;
 		this.hasMatch = false;
 
+		this.set( 'isEnabled', true );
+
 		this._startListening();
 	}
 
@@ -44,6 +47,11 @@ export default class TextWatcher {
 		const document = model.document;
 
 		this.listenTo( document.selection, 'change:range', ( evt, { directChange } ) => {
+			// Evaluate text before a selection only when TextWatcher is enabled.
+			if ( !this.isEnabled ) {
+				return;
+			}
+
 			// Indirect changes (i.e. when the user types or external changes are applied) are handled in the document's change event.
 			if ( !directChange ) {
 				return;
@@ -63,6 +71,11 @@ export default class TextWatcher {
 		} );
 
 		this.listenTo( document, 'change:data', ( evt, batch ) => {
+			// Evaluate text before a selection only when TextWatcher is enabled.
+			if ( !this.isEnabled ) {
+				return;
+			}
+
 			if ( batch.type == 'transparent' ) {
 				return;
 			}
@@ -127,4 +140,4 @@ export default class TextWatcher {
 	}
 }
 
-mix( TextWatcher, EmitterMixin );
+mix( TextWatcher, EmitterMixin, ObservableMixin );

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -34,6 +34,16 @@ export default class TextWatcher {
 
 		this.set( 'isEnabled', true );
 
+		// Toggle text watching on isEnabled state change.
+		this.on( 'change:isEnabled', () => {
+			if ( this.isEnabled ) {
+				this._startListening();
+			} else {
+				this.stopListening( model.document.selection );
+				this.stopListening( model.document );
+			}
+		} );
+
 		this._startListening();
 	}
 
@@ -47,11 +57,6 @@ export default class TextWatcher {
 		const document = model.document;
 
 		this.listenTo( document.selection, 'change:range', ( evt, { directChange } ) => {
-			// Evaluate text before a selection only when TextWatcher is enabled.
-			if ( !this.isEnabled ) {
-				return;
-			}
-
 			// Indirect changes (i.e. when the user types or external changes are applied) are handled in the document's change event.
 			if ( !directChange ) {
 				return;
@@ -71,11 +76,6 @@ export default class TextWatcher {
 		} );
 
 		this.listenTo( document, 'change:data', ( evt, batch ) => {
-			// Evaluate text before a selection only when TextWatcher is enabled.
-			if ( !this.isEnabled ) {
-				return;
-			}
-
 			if ( batch.type == 'transparent' ) {
 				return;
 			}

--- a/src/textwatcher.js
+++ b/src/textwatcher.js
@@ -34,7 +34,7 @@ export default class TextWatcher {
 		this.hasMatch = false;
 
 		/**
-		 * Flag indicating whether the TextWatcher is enabled or disabled.
+		 * Flag indicating whether the `TextWatcher` instance is enabled or disabled.
 		 * A disabled TextWatcher will not evaluate text.
 		 *
 		 * To disable TextWatcher:

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -57,29 +57,6 @@ describe( 'Text transformation feature', () => {
 		it( 'should be enabled after initialization', () => {
 			expect( plugin.isEnabled ).to.be.true;
 		} );
-
-		it( 'should have active watchers when is enabled', () => {
-			const enableWatchersSpy = sinon.spy( plugin, '_enableTransformationWatchers' );
-
-			plugin.isEnabled = false;
-			plugin.isEnabled = true;
-
-			expect( plugin.isEnabled ).to.be.true;
-			expect( plugin._watchersStack.size ).to.be.at.least( 1 );
-			sinon.assert.calledOnce( enableWatchersSpy );
-		} );
-
-		it( 'should not have active watchers when is disabled', () => {
-			const disableWatchersSpy = sinon.spy( plugin, '_disableTransformationWatchers' );
-
-			plugin.isEnabled = false;
-
-			expect( plugin.isEnabled ).to.be.false;
-
-			sinon.assert.calledOnce( disableWatchersSpy );
-
-			expect( plugin._watchersStack.size ).to.be.equal( 0 );
-		} );
 	} );
 
 	describe( 'transformations', () => {

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -41,7 +41,7 @@ describe( 'Text transformation feature', () => {
 		} );
 	} );
 
-	describe( 'plugin', () => {
+	describe( '#isEnabled', () => {
 		let plugin;
 
 		beforeEach( () => {
@@ -55,17 +55,7 @@ describe( 'Text transformation feature', () => {
 		} );
 
 		it( 'should be enabled after initialization', () => {
-			plugin.init();
-
 			expect( plugin.isEnabled ).to.be.true;
-		} );
-
-		it( 'should initialize watchers after initialization', () => {
-			const enableWatchersSpy = sinon.spy( plugin, '_enableTransformationWatchers' );
-
-			plugin.init();
-
-			sinon.assert.calledOnce( enableWatchersSpy );
 		} );
 
 		it( 'should have active watchers when is enabled', () => {

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -204,6 +204,19 @@ describe( 'Text transformation feature', () => {
 				.to.equal( '<paragraph>"Foo <softBreak></softBreak>“Bar”</paragraph>' );
 		} );
 
+		it( 'should be disabled inside code blocks', () => {
+			setData( model, '<codeBlock language="plaintext">some [] code</codeBlock>' );
+
+			simulateTyping( '1/2' );
+
+			const plugin = editor.plugins.get( 'TextTransformation' );
+
+			expect( plugin.isEnabled ).to.be.false;
+			expect( plugin._watchersStack.size ).to.be.equal( 0 );
+			expect( getData( model, { withoutSelection: true } ) )
+				.to.equal( '<codeBlock language="plaintext">some 1/2 code</codeBlock>' );
+		} );
+
 		function testTransformation( transformFrom, transformTo, textInParagraph = 'A foo' ) {
 			it( `should transform "${ transformFrom }" to "${ transformTo }"`, () => {
 				setData( model, `<paragraph>${ textInParagraph }[]</paragraph>` );

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -50,6 +50,10 @@ describe( 'Text transformation feature', () => {
 			} );
 		} );
 
+		afterEach( () => {
+			plugin.destroy();
+		} );
+
 		it( 'should be enabled after initialization', () => {
 			plugin.init();
 

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -11,7 +11,7 @@ import TextTransformation from '../src/texttransformation';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockediting';
+import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
 
 describe( 'Text transformation feature', () => {
 	let editorElement, editor, model, doc;
@@ -417,7 +417,7 @@ describe( 'Text transformation feature', () => {
 	function createEditorInstance( additionalConfig = {} ) {
 		return ClassicTestEditor
 			.create( editorElement, Object.assign( {
-				plugins: [ Typing, Paragraph, Bold, TextTransformation, CodeBlockEditing ]
+				plugins: [ Typing, Paragraph, Bold, TextTransformation, CodeBlock ]
 			}, additionalConfig ) )
 			.then( newEditor => {
 				editor = newEditor;

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -46,7 +46,7 @@ describe( 'Text transformation feature', () => {
 
 		beforeEach( () => {
 			return createEditorInstance().then( () => {
-				TextTransformationPlugin = editor.plugins.get( 'TextTransformation' );
+				TextTransformationPlugin = editor.plugins.get( TextTransformation );
 			} );
 		} );
 
@@ -64,23 +64,26 @@ describe( 'Text transformation feature', () => {
 			sinon.assert.calledOnce( enableWatchersSpy );
 		} );
 
-		it( 'should disable watchers when is disabled', () => {
+		it( 'should have active watchers when is enabled', () => {
+			const enableWatchersSpy = sinon.spy( TextTransformationPlugin, '_enableTransformationWatchers' );
+
+			TextTransformationPlugin.isEnabled = false;
+			TextTransformationPlugin.isEnabled = true;
+
+			expect( TextTransformationPlugin.isEnabled ).to.be.true;
+			expect( TextTransformationPlugin._watchersStack.size ).to.be.at.least( 1 );
+			sinon.assert.calledOnce( enableWatchersSpy );
+		} );
+
+		it( 'should not have active watchers when is disabled', () => {
 			const disableWatchersSpy = sinon.spy( TextTransformationPlugin, '_disableTransformationWatchers' );
 
 			TextTransformationPlugin.isEnabled = false;
 
-			sinon.assert.calledOnce( disableWatchersSpy );
-		} );
-
-		it( 'should have active watchers when is enabled', () => {
-			expect( TextTransformationPlugin.isEnabled ).to.be.true;
-			expect( TextTransformationPlugin._watchersStack.size ).to.be.at.least( 1 );
-		} );
-
-		it( 'should not have active watchers when is disabled', () => {
-			TextTransformationPlugin.isEnabled = false;
-
 			expect( TextTransformationPlugin.isEnabled ).to.be.false;
+
+			sinon.assert.calledOnce( disableWatchersSpy );
+
 			expect( TextTransformationPlugin._watchersStack.size ).to.be.equal( 0 );
 		} );
 	} );
@@ -208,7 +211,6 @@ describe( 'Text transformation feature', () => {
 			const plugin = editor.plugins.get( 'TextTransformation' );
 
 			expect( plugin.isEnabled ).to.be.false;
-			expect( plugin._watchersStack.size ).to.be.equal( 0 );
 			expect( getData( model, { withoutSelection: true } ) )
 				.to.equal( '<codeBlock language="plaintext">some 1/2 code</codeBlock>' );
 		} );

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -42,35 +42,31 @@ describe( 'Text transformation feature', () => {
 	} );
 
 	describe( 'plugin', () => {
-		let TextTransformationPlugin, enableWatchersSpy, disableWatchersSpy;
+		let TextTransformationPlugin;
 
 		beforeEach( () => {
-			TextTransformationPlugin = new TextTransformation( editor );
-			enableWatchersSpy = sinon.spy( TextTransformationPlugin, '_enableTransformationWatchers' );
-			disableWatchersSpy = sinon.spy( TextTransformationPlugin, '_disableTransformationWatchers' );
-
-			TextTransformationPlugin.init();
+			return createEditorInstance().then( () => {
+				TextTransformationPlugin = editor.plugins.get( 'TextTransformation' );
+			} );
 		} );
 
 		it( 'should be enabled after initialization', () => {
+			TextTransformationPlugin.init();
+
 			expect( TextTransformationPlugin.isEnabled ).to.be.true;
 		} );
 
 		it( 'should initialize watchers after initialization', () => {
+			const enableWatchersSpy = sinon.spy( TextTransformationPlugin, '_enableTransformationWatchers' );
+
+			TextTransformationPlugin.init();
+
 			sinon.assert.calledOnce( enableWatchersSpy );
-		} );
-
-		it( 'should initialize watchers again when is enabled', () => {
-			sinon.assert.calledOnce( enableWatchersSpy );
-
-			TextTransformationPlugin.isEnabled = false;
-			TextTransformationPlugin.isEnabled = true;
-
-			sinon.assert.calledTwice( enableWatchersSpy );
-			expect( TextTransformationPlugin._watchersStack.size ).to.be.at.least( 1 );
 		} );
 
 		it( 'should disable watchers when is disabled', () => {
+			const disableWatchersSpy = sinon.spy( TextTransformationPlugin, '_disableTransformationWatchers' );
+
 			TextTransformationPlugin.isEnabled = false;
 
 			sinon.assert.calledOnce( disableWatchersSpy );

--- a/tests/texttransformation.js
+++ b/tests/texttransformation.js
@@ -42,49 +42,49 @@ describe( 'Text transformation feature', () => {
 	} );
 
 	describe( 'plugin', () => {
-		let TextTransformationPlugin;
+		let plugin;
 
 		beforeEach( () => {
 			return createEditorInstance().then( () => {
-				TextTransformationPlugin = editor.plugins.get( TextTransformation );
+				plugin = editor.plugins.get( TextTransformation );
 			} );
 		} );
 
 		it( 'should be enabled after initialization', () => {
-			TextTransformationPlugin.init();
+			plugin.init();
 
-			expect( TextTransformationPlugin.isEnabled ).to.be.true;
+			expect( plugin.isEnabled ).to.be.true;
 		} );
 
 		it( 'should initialize watchers after initialization', () => {
-			const enableWatchersSpy = sinon.spy( TextTransformationPlugin, '_enableTransformationWatchers' );
+			const enableWatchersSpy = sinon.spy( plugin, '_enableTransformationWatchers' );
 
-			TextTransformationPlugin.init();
+			plugin.init();
 
 			sinon.assert.calledOnce( enableWatchersSpy );
 		} );
 
 		it( 'should have active watchers when is enabled', () => {
-			const enableWatchersSpy = sinon.spy( TextTransformationPlugin, '_enableTransformationWatchers' );
+			const enableWatchersSpy = sinon.spy( plugin, '_enableTransformationWatchers' );
 
-			TextTransformationPlugin.isEnabled = false;
-			TextTransformationPlugin.isEnabled = true;
+			plugin.isEnabled = false;
+			plugin.isEnabled = true;
 
-			expect( TextTransformationPlugin.isEnabled ).to.be.true;
-			expect( TextTransformationPlugin._watchersStack.size ).to.be.at.least( 1 );
+			expect( plugin.isEnabled ).to.be.true;
+			expect( plugin._watchersStack.size ).to.be.at.least( 1 );
 			sinon.assert.calledOnce( enableWatchersSpy );
 		} );
 
 		it( 'should not have active watchers when is disabled', () => {
-			const disableWatchersSpy = sinon.spy( TextTransformationPlugin, '_disableTransformationWatchers' );
+			const disableWatchersSpy = sinon.spy( plugin, '_disableTransformationWatchers' );
 
-			TextTransformationPlugin.isEnabled = false;
+			plugin.isEnabled = false;
 
-			expect( TextTransformationPlugin.isEnabled ).to.be.false;
+			expect( plugin.isEnabled ).to.be.false;
 
 			sinon.assert.calledOnce( disableWatchersSpy );
 
-			expect( TextTransformationPlugin._watchersStack.size ).to.be.equal( 0 );
+			expect( plugin._watchersStack.size ).to.be.equal( 0 );
 		} );
 	} );
 

--- a/tests/textwatcher.js
+++ b/tests/textwatcher.js
@@ -40,7 +40,6 @@ describe( 'TextWatcher', () => {
 
 	afterEach( () => {
 		sinon.restore();
-		watcher.off();
 
 		if ( editor ) {
 			return editor.destroy();

--- a/tests/textwatcher.js
+++ b/tests/textwatcher.js
@@ -40,10 +40,23 @@ describe( 'TextWatcher', () => {
 
 	afterEach( () => {
 		sinon.restore();
+		watcher.off();
 
 		if ( editor ) {
 			return editor.destroy();
 		}
+	} );
+
+	describe( '#isEnabled', () => {
+		it( 'should be enabled after initialization', () => {
+			expect( watcher.isEnabled ).to.be.true;
+		} );
+
+		it( 'should be disabled after setting #isEnabled to false', () => {
+			watcher.isEnabled = false;
+
+			expect( watcher.isEnabled ).to.be.false;
+		} );
 	} );
 
 	describe( 'testCallback', () => {
@@ -97,6 +110,35 @@ describe( 'TextWatcher', () => {
 
 			sinon.assert.notCalled( testCallbackStub );
 		} );
+
+		it( 'should not evaluate text when watcher is disabled', () => {
+			watcher.isEnabled = false;
+
+			model.change( writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.notCalled( testCallbackStub );
+		} );
+
+		it( 'should evaluate text when watcher is enabled again', () => {
+			watcher.isEnabled = false;
+
+			model.change( writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.notCalled( testCallbackStub );
+
+			watcher.isEnabled = true;
+
+			model.change( writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.calledOnce( testCallbackStub );
+			sinon.assert.calledWithExactly( testCallbackStub, 'foo @@' );
+		} );
 	} );
 
 	describe( 'events', () => {
@@ -109,6 +151,22 @@ describe( 'TextWatcher', () => {
 
 			sinon.assert.calledOnce( testCallbackStub );
 			sinon.assert.calledOnce( matchedDataSpy );
+			sinon.assert.notCalled( matchedSelectionSpy );
+			sinon.assert.notCalled( unmatchedSpy );
+		} );
+
+		it( 'should not fire "matched:data" event when watcher is disabled' +
+		' (even when test callback returns true for model data changes)', () => {
+			watcher.isEnabled = false;
+
+			testCallbackStub.returns( true );
+
+			model.change( writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.notCalled( testCallbackStub );
+			sinon.assert.notCalled( matchedDataSpy );
 			sinon.assert.notCalled( matchedSelectionSpy );
 			sinon.assert.notCalled( unmatchedSpy );
 		} );
@@ -127,6 +185,26 @@ describe( 'TextWatcher', () => {
 			sinon.assert.calledOnce( testCallbackStub );
 			sinon.assert.notCalled( matchedDataSpy );
 			sinon.assert.calledOnce( matchedSelectionSpy );
+			sinon.assert.notCalled( unmatchedSpy );
+		} );
+
+		it( 'should not fire "matched:selection" event when when watcher is disabled' +
+		' (even when test callback returns true for model data changes)', () => {
+			watcher.isEnabled = false;
+
+			testCallbackStub.returns( true );
+
+			model.enqueueChange( 'transparent', writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			model.change( writer => {
+				writer.setSelection( doc.getRoot().getChild( 0 ), 0 );
+			} );
+
+			sinon.assert.notCalled( testCallbackStub );
+			sinon.assert.notCalled( matchedDataSpy );
+			sinon.assert.notCalled( matchedSelectionSpy );
 			sinon.assert.notCalled( unmatchedSpy );
 		} );
 
@@ -188,6 +266,31 @@ describe( 'TextWatcher', () => {
 			sinon.assert.notCalled( matchedSelectionSpy );
 			sinon.assert.calledOnce( unmatchedSpy );
 		} );
+
+		it( 'should not fire "umatched" event when selection is expanded if watcher is disabled', () => {
+			watcher.isEnabled = false;
+
+			testCallbackStub.returns( true );
+
+			model.change( writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.notCalled( testCallbackStub );
+			sinon.assert.notCalled( matchedDataSpy );
+			sinon.assert.notCalled( matchedSelectionSpy );
+			sinon.assert.notCalled( unmatchedSpy );
+
+			model.change( writer => {
+				const start = writer.createPositionAt( doc.getRoot().getChild( 0 ), 0 );
+
+				writer.setSelection( writer.createRange( start, start.getShiftedBy( 1 ) ) );
+			} );
+
+			sinon.assert.notCalled( testCallbackStub );
+			sinon.assert.notCalled( matchedDataSpy );
+			sinon.assert.notCalled( matchedSelectionSpy );
+			sinon.assert.notCalled( unmatchedSpy );
+		} );
 	} );
 } );
-


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Disabled text transformation inside code blocks. Closes ckeditor/ckeditor5#5862.
