### PR TITLE
i/6304: Add info that the TextTransformation plugin is installed in all builds by default

### DIFF
--- a/docs/features/text-transformation.md
+++ b/docs/features/text-transformation.md
@@ -171,6 +171,9 @@ ClassicEditor
 	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
 </info-box>
 
+The plugin is installed in all {@link builds/guides/overview#available-builds builds} by dafault.
+
+
 ## Contribute
 
 The source code of the feature is available on GitHub in https://github.com/ckeditor/ckeditor5-typing.

--- a/docs/features/text-transformation.md
+++ b/docs/features/text-transformation.md
@@ -148,6 +148,10 @@ You can test the custom rules defined above in the demo:
 
 ## Installation
 
+<info-box info>
+	This feature is enabled by default in all builds. The installation instructions are for developers interested in building their own, custom rich text editor.
+</info-box>
+
 To add this feature to your rich-text editor, install the [`@ckeditor/ckeditor5-typing`](https://www.npmjs.com/package/@ckeditor/ckeditor5-typing) package:
 
 ```bash
@@ -170,9 +174,6 @@ ClassicEditor
 <info-box info>
 	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
 </info-box>
-
-The plugin is installed in all {@link builds/guides/overview#available-builds builds} by dafault.
-
 
 ## Contribute
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Added info that the TextTransformation plugin is installed in all build by default. Closes ckeditor/ckeditor5#6304.

---
Required PRs before merge:
- [x] https://github.com/ckeditor/ckeditor5-build-decoupled-document/pull/34
- [x] https://github.com/ckeditor/ckeditor5-build-inline/pull/21
- [x] https://github.com/ckeditor/ckeditor5-build-classic/pull/101
- [x] https://github.com/ckeditor/ckeditor5-build-balloon-block/pull/16
- [x] https://github.com/ckeditor/ckeditor5-build-balloon/pull/38